### PR TITLE
Prose margin overrides

### DIFF
--- a/src/styles/custom-components.less
+++ b/src/styles/custom-components.less
@@ -201,7 +201,7 @@
     }
 
     .ProseMirror-selectednode {
-        box-shadow: 0 0 0 4px var(--blue-100); // todo: should be var(--bs-ring) but that doesn't seem to be available here?
+        box-shadow: 0 0 0 4px var(--focus-ring);
     }
 
     // reset whitespace to normal inside externally sourced widgets


### PR DESCRIPTION
Our editor often wraps things in their own divs. This PR adds proper spacing below them.