### PR TITLE
Fix overly eager underscore escaping

### DIFF
--- a/src/rich-text/markdown-serializer.ts
+++ b/src/rich-text/markdown-serializer.ts
@@ -132,7 +132,7 @@ const defaultMarkdownSerializerNodes: MarkdownSerializerNodes = {
         let escapedText = state.esc(node.text, startOfLine);
 
         // built in escape doesn't get all the cases TODO upstream!
-        escapedText = escapedText.replace(/\\_/g, "\\\\_");
+        escapedText = escapedText.replace(/\b_|_\b/g, "\\_");
 
         state.text(escapedText, false);
     },

--- a/src/rich-text/markdown-serializer.ts
+++ b/src/rich-text/markdown-serializer.ts
@@ -132,7 +132,7 @@ const defaultMarkdownSerializerNodes: MarkdownSerializerNodes = {
         let escapedText = state.esc(node.text, startOfLine);
 
         // built in escape doesn't get all the cases TODO upstream!
-        escapedText = escapedText.replace(/_/g, "\\_");
+        escapedText = escapedText.replace(/\\_/g, "\\\\_");
 
         state.text(escapedText, false);
     },

--- a/test/rich-text/markdown-serializer.test.ts
+++ b/test/rich-text/markdown-serializer.test.ts
@@ -204,7 +204,11 @@ describe("markdown-serializer", () => {
         }
     );
 
-    const escapeData = [String.raw`¯\\\_(ツ)_/¯`];
+    const escapeData = [
+        String.raw`¯\\\_(ツ)_/¯`,
+        String.raw`\_not-underlined\_`,
+        String.raw`http://www.example.com/dont_escape_urls`,
+    ];
 
     it.each(escapeData)(
         "should escape plain-text containing markdown characters",

--- a/test/rich-text/markdown-serializer.test.ts
+++ b/test/rich-text/markdown-serializer.test.ts
@@ -205,8 +205,9 @@ describe("markdown-serializer", () => {
     );
 
     const escapeData = [
-        String.raw`¯\\\_(ツ)_/¯`,
+        String.raw`¯\\\_(ツ)\_/¯`,
         String.raw`\_not-underlined\_`,
+        String.raw`_intra_text_underlines_also_underlined_`,
         String.raw`http://www.example.com/dont_escape_urls`,
     ];
 

--- a/test/rich-text/markdown-serializer.test.ts
+++ b/test/rich-text/markdown-serializer.test.ts
@@ -204,7 +204,7 @@ describe("markdown-serializer", () => {
         }
     );
 
-    const escapeData = [String.raw`¯\\\_(ツ)\_/¯`];
+    const escapeData = [String.raw`¯\\\_(ツ)_/¯`];
 
     it.each(escapeData)(
         "should escape plain-text containing markdown characters",

--- a/test/rich-text/markdown-serializer.test.ts
+++ b/test/rich-text/markdown-serializer.test.ts
@@ -206,9 +206,9 @@ describe("markdown-serializer", () => {
 
     const escapeData = [
         String.raw`¯\\\_(ツ)\_/¯`,
-        String.raw`\_not-underlined\_`,
-        String.raw`_intra_text_underlines_also_underlined_`,
-        String.raw`http://www.example.com/dont_escape_urls`,
+        String.raw`\_not-emphasized\_`,
+        String.raw`_intra_text_underscores_are_not_emphasized_`,
+        String.raw`http://www.example.com/dont_emphasize_urls`,
     ];
 
     it.each(escapeData)(


### PR DESCRIPTION
Our `markdown-serializer` uses custom escape logic when serializing text nodes entered in rich-text mode. This custom escaping is a little too eager and causes problems with URLs that contain underscores.

Take an URL like this entered in rich-text mode:

```
https://example.com/some_path_here
```

When switching over to markdown mode (or saving the document as markdown), this would get converted to:

```
https://example.com/some\_path\_here
```

which is problematic for URLs (and the autolinking we do) since it messes with the original URL.

This PR makes our custom escape logic more strict. I'm not sure if this is causing any regressions I didn't check yet, but our test suite is only raising shruggie as the single problem that might arise. With this tweak, you can still enter a shruggie in rich-text mode and convert to markdown and back again.