### PR TITLE
Link popover: Fix messed up margin when editing

### DIFF
--- a/src/rich-text/plugins/link-tooltip.ts
+++ b/src/rich-text/plugins/link-tooltip.ts
@@ -51,7 +51,7 @@ class LinkTooltip {
             class="wmx3 grid--cell fs-body1 fw-normal d-inline-block truncate ml8 mr4"
             target="_blank"
             rel="nofollow noreferrer">${this.href}</a>
-        <div class="grid--cell d-none wmn2 ml2 mr4 js-link-tooltip-input-wrapper">
+        <div class="grid--cell d-none wmn2 ml2 mr4 mb0 js-link-tooltip-input-wrapper">
             <input type="text"
                     class="s-input s-input__sm js-link-tooltip-input"
                     autocomplete="off"


### PR DESCRIPTION
When editing a link in rich-text mode, the input field gets extra bottom margin. That's due to a rather generous CSS rule in our `custom-components.less` that's got a lot of potential to mess with _any_ of our custom node views that use a `div` element:

```less
&.s-prose div {
        margin-bottom: var(--s-prose-spacing);
```

Here's what it currently looks like:

![Screenshot 2021-01-20 at 12 22 05](https://user-images.githubusercontent.com/491469/105168596-9f034100-5b1a-11eb-9949-00590614804c.png)

In this PR I'm adding an explicit `mb0` to solve the immediate issue. We should think about making that custom CSS rule a little more specific.

Here's what it looks like with the fix in place:

![Screenshot 2021-01-20 at 12 24 06](https://user-images.githubusercontent.com/491469/105168832-f9040680-5b1a-11eb-8d29-31b4dacfcca1.png)
