### PR TITLE
Remove smart quotes, ellipsis, emdash input rules

### DIFF
--- a/src/rich-text/inputrules.ts
+++ b/src/rich-text/inputrules.ts
@@ -1,8 +1,5 @@
 import {
-    ellipsis,
-    emDash,
     inputRules,
-    smartQuotes,
     textblockTypeInputRule,
     wrappingInputRule,
 } from "prosemirror-inputrules";
@@ -33,17 +30,12 @@ const orderedListRule = wrappingInputRule(
  * Defines all input rules we're using in our rich-text editor.
  * Input rules are formatting operations that trigger as you type based on regular expressions
  *
- * We're reusing some of the built-in input rules like "smart quotes" or "ellipsis".
- *
  * Examples:
  *      * starting a line with "# " will turn the line into a headline
  *      * starting a line with "> " will insert a new blockquote in place
  */
 export const richTextInputRules = inputRules({
     rules: [
-        emDash,
-        ellipsis,
-        ...smartQuotes,
         blockquoteInputRule,
         headingInputRule,
         codeBlockRule,

--- a/test/e2e/editor.e2e.test.ts
+++ b/test/e2e/editor.e2e.test.ts
@@ -116,15 +116,14 @@ describe("rich-text mode", () => {
     });
 
     describe("input rules", () => {
-        it.each([
-            [`"`, `“`],
-            ["...", "…"],
-            ["--", "—"],
-        ])("should transform special characters", async (input, expected) => {
-            await typeText(input);
-            const text = await page.innerText(editorSelector);
-            expect(text).toBe(expected);
-        });
+        it.each([`"`, "...", "--"])(
+            "should not transform special characters",
+            async (input) => {
+                await typeText(input);
+                const text = await page.innerText(editorSelector);
+                expect(text).toBe(input);
+            }
+        );
     });
 
     describe("editing images", () => {


### PR DESCRIPTION
[Feedback on meta](https://meta.stackexchange.com/a/360067/507720) shows that automatically converting quotes to smart quotes in rich-text mode doesn't spark joy.

The reasoning is sound. On a programming website quotes often occur in code samples. Converting them to smart quotes will break code samples and we all know how much people love copy/pasting code samples.

This PR removes the usage of a bunch of Prosemirror's input rules that could make developers' lives harder:

* converting quotes to smart quotes (both, single and double quotes)
* converting `...` to &hellip;
* converting `--` to —

All of the above are used in code in some form: `--` is a decrement operator, `...` is used as the spread operator in JS and quotes are... quotes.

We should not try to be smart about these things. If people are adamant using smart quotes or typographically correct characters, they'll most likely know how to enter them (e.g. by using their operating system's settings or using Alt codes).

These input rules haven't been a deliberately requested feature anyways. I remember adding them as we were still in the prototyping phase and I didn't think much about it. Seems like the made it all the way to production because that's what good prototypes do.

If we find out that people want to keep these as an opt-in option, we can still bring them back as a setting for the editor or special sites on the network. For now: Let's get rid of them.