### PR TITLE
Fix "enter" key in Firefox + Markdown mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@types/prosemirror-model": "^1.11.1",
                 "@types/prosemirror-schema-list": "^1.0.1",
                 "@types/prosemirror-state": "^1.2.5",
-                "@types/prosemirror-view": "^1.17.0",
+                "@types/prosemirror-view": "1.16.0",
                 "markdown-it": "^10.0.0",
                 "prosemirror-commands": "^1.1.4",
                 "prosemirror-highlightjs": "^0.5.1",
@@ -33,7 +33,7 @@
                 "prosemirror-schema-list": "^1.1.4",
                 "prosemirror-state": "^1.3.3",
                 "prosemirror-transform": "^1.2.8",
-                "prosemirror-view": "^1.17.1"
+                "prosemirror-view": "1.16.5"
             },
             "devDependencies": {
                 "@babel/core": "^7.12.10",
@@ -2015,9 +2015,9 @@
             }
         },
         "node_modules/@types/prosemirror-view": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.17.0.tgz",
-            "integrity": "sha512-1OALGaiRmq3c+Y35QVrqqlEykWEszYYx08jAPBhYe6M+YbC6Y2LnmCDXjEOTI1oToJwoADHFPGHl4W59L3fgGg==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.16.0.tgz",
+            "integrity": "sha512-egACYfElDnzVIJNDenitpLEyjxqlh9T2zhPH1xe88oVUlwJCb64SbBSn/JSUkqTpb0hRH8JKl74OHLm6QER+Kw==",
             "dependencies": {
                 "@types/prosemirror-model": "*",
                 "@types/prosemirror-state": "*",
@@ -13298,9 +13298,9 @@
             }
         },
         "node_modules/prosemirror-view": {
-            "version": "1.17.1",
-            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.17.1.tgz",
-            "integrity": "sha512-n56IjZoJKEQYTh43KVmXMwJPQ+q4jEoPK7vhrb86Q//NxvNdzXWBPM0O8RhMD0wZBZS87WA+TQbftLq4p9WGrg==",
+            "version": "1.16.5",
+            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.16.5.tgz",
+            "integrity": "sha512-cFEjzhqQZIRDALEgQt8CNn+Qb+BUOvNxxaljaWoCbAYlsWGMiNNQG06I1MwbRNDcwnZKeFmOGpLEB4eorYYGig==",
             "dependencies": {
                 "prosemirror-model": "^1.1.0",
                 "prosemirror-state": "^1.0.0",
@@ -19621,9 +19621,9 @@
             }
         },
         "@types/prosemirror-view": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.17.0.tgz",
-            "integrity": "sha512-1OALGaiRmq3c+Y35QVrqqlEykWEszYYx08jAPBhYe6M+YbC6Y2LnmCDXjEOTI1oToJwoADHFPGHl4W59L3fgGg==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.16.0.tgz",
+            "integrity": "sha512-egACYfElDnzVIJNDenitpLEyjxqlh9T2zhPH1xe88oVUlwJCb64SbBSn/JSUkqTpb0hRH8JKl74OHLm6QER+Kw==",
             "requires": {
                 "@types/prosemirror-model": "*",
                 "@types/prosemirror-state": "*",
@@ -29455,9 +29455,9 @@
             }
         },
         "prosemirror-view": {
-            "version": "1.17.1",
-            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.17.1.tgz",
-            "integrity": "sha512-n56IjZoJKEQYTh43KVmXMwJPQ+q4jEoPK7vhrb86Q//NxvNdzXWBPM0O8RhMD0wZBZS87WA+TQbftLq4p9WGrg==",
+            "version": "1.16.5",
+            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.16.5.tgz",
+            "integrity": "sha512-cFEjzhqQZIRDALEgQt8CNn+Qb+BUOvNxxaljaWoCbAYlsWGMiNNQG06I1MwbRNDcwnZKeFmOGpLEB4eorYYGig==",
             "requires": {
                 "prosemirror-model": "^1.1.0",
                 "prosemirror-state": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "@types/prosemirror-model": "^1.11.1",
         "@types/prosemirror-schema-list": "^1.0.1",
         "@types/prosemirror-state": "^1.2.5",
-        "@types/prosemirror-view": "^1.17.0",
+        "@types/prosemirror-view": "1.16.0",
         "markdown-it": "^10.0.0",
         "prosemirror-commands": "^1.1.4",
         "prosemirror-highlightjs": "^0.5.1",
@@ -93,7 +93,7 @@
         "prosemirror-schema-list": "^1.1.4",
         "prosemirror-state": "^1.3.3",
         "prosemirror-transform": "^1.2.8",
-        "prosemirror-view": "^1.17.1"
+        "prosemirror-view": "1.16.5"
     },
     "peerDependencies": {
         "highlight.js": "^10.5.0"


### PR DESCRIPTION
When using Firefox and writing something in Markdown mode, our current version of the editor has this weird issue where hitting <kbd>Enter</kbd> doesn't trigger a newline immediately. You have to type a second key to trigger the cursor to move down a line. There's a corresponding [report on meta.SE](https://meta.stackexchange.com/a/360036/507720).

I could narrow down that this behavior was introduced with [this commit](https://github.com/StackExchange/Stacks-Editor/commit/6fd38a5d24f2f18b65c68ecab87120ba5752adb4). When digging deeper, I could figure out that `prosemirror-view` introduces this behavior with all versions >= `1.17.0`. Version `1.16.5` doesn't have this issue.

I don't know what precisely is causing this problem. The changes in `prosemirror-view` don't look jarring and I couldn't find any traces that our own usage of any of the changed functions could be triggering this. For now it might be best to roll back to the last stable version and investigate what's going on.

**Reproducing the issue**
The issue is somewhat sneaky. It's only an `Enter` hit at the end of a document that doesn't move the cursor properly immediately. If you put your cursor into the middle of the document and hit `Enter` it works just fine.

**Update**
This is certainly an issue with `prosemirror-view` itself. I was able to reproduce this with Firefox on the example editor on the prosemirror.net front page. If you go there, empty the editor, select "type" - "code block" and start typing, you'll see the same issue. I filed a bug there.