### PR TITLE
Exploration: Preview Pane for Markdown Mode

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -166,11 +166,27 @@ And finally, Stack Snippets:
     </div>
 
 <!-- end snippet -->
-        </textarea>
-        <h1>Stacks Editor</h1>
-        <h3>Showcasing our new editing experience for Stack Overflow</h3>
-        <div id="example-1"></div>
-    </div>
-</body>
-
+        </textarea
+            >
+            <h1>Stacks Editor</h1>
+            <h3>Showcasing our new editing experience for Stack Overflow</h3>
+            <div id="example-1"></div>
+            <button
+                class="s-btn js-preview-toggle"
+                data-controller="s-expandable-control"
+                data-s-expandable-control-toggle-class="is-selected"
+                aria-expanded="false"
+                aria-controls="js-preview-expander"
+            >
+                Show preview
+            </button>
+            <div class="s-expandable" id="js-preview-expander">
+                <div
+                    class="js-preview-pane mt12 p12 s-card s-prose d-none s-expandable--content"
+                >
+                    Preview will appear here
+                </div>
+            </div>
+        </div>
+    </body>
 </html>

--- a/site/index.ts
+++ b/site/index.ts
@@ -111,6 +111,7 @@ domReady(() => {
     // create the editor
     const place = document.querySelector<HTMLElement>("#example-1");
     const content = document.querySelector<HTMLTextAreaElement>("#content");
+    const preview = document.querySelector<HTMLElement>(".js-preview-pane");
     const enableTables = place.classList.contains("js-tables-enabled");
     const enableImages = !place.classList.contains("js-images-disabled");
 
@@ -133,7 +134,7 @@ domReady(() => {
         const editorInstance = new StacksEditor(place, content.value, {
             defaultView: getDefaultEditor(),
             editorHelpLink: "#TODO",
-            commonmarkOptions: {},
+            commonmarkOptions: { previewTarget: preview },
             parserFeatures: {
                 tables: enableTables,
                 tagLinks: {

--- a/src/commonmark/editor.ts
+++ b/src/commonmark/editor.ts
@@ -71,7 +71,9 @@ export class CommonmarkEditor extends BaseView {
             }
         );
 
-        this.setupPreviewPane(target);
+        if (options.previewTarget) {
+            this.setupPreviewPane(options.previewTarget);
+        }
 
         log(
             "prosemirror commonmark document",
@@ -79,11 +81,10 @@ export class CommonmarkEditor extends BaseView {
         );
     }
 
-    setupPreviewPane(target: Node) {
-        const preview = document.createElement("div");
-        preview.className = "mt12 p12 s-card s-prose js-preview-pane";
-        preview.innerText = "Preview will appear here";
-        target.parentElement.appendChild(preview);
+    setupPreviewPane(target: HTMLElement): void {
+        const renderDelayMs = 500; // tweak this to make rendering more or less immediate
+
+        this.options.previewTarget.classList.remove("d-none");
 
         this.markdownRenderer = buildMarkdownParser(
             this.options.parserFeatures,
@@ -91,13 +92,13 @@ export class CommonmarkEditor extends BaseView {
             null
         );
 
-        let syncPreview = (): void => {
-            preview.innerHTML = this.markdownRenderer.tokenizer.render(
+        const syncPreview = (): void => {
+            target.innerHTML = this.markdownRenderer.tokenizer.render(
                 this.content
             );
         };
 
-        const debouncedSync = debounce(syncPreview, 300);
+        const debouncedSync = debounce(syncPreview, renderDelayMs);
 
         this.editorView.props.handleKeyDown = (view: EditorView) => {
             debouncedSync();
@@ -117,6 +118,11 @@ export class CommonmarkEditor extends BaseView {
                 handler: defaultImageUploadHandler,
             },
         };
+    }
+
+    destroy(): void {
+        super.destroy();
+        this.options.previewTarget?.classList.add("d-none");
     }
 
     parseContent(content: string): ProseMirrorNode {

--- a/src/shared/markdown-parser.ts
+++ b/src/shared/markdown-parser.ts
@@ -169,7 +169,7 @@ interface MarkdownParserState {
  * We do this because we need some special functionality that is not exposed by default with the existing
  * handler generation code (from adding tokens)
  */
-class SOMarkdownParser extends MarkdownParser {
+export class SOMarkdownParser extends MarkdownParser {
     // TODO map the (private?) backing property not exposed by the typings
     declare tokenizer: MarkdownIt;
 

--- a/src/shared/view.ts
+++ b/src/shared/view.ts
@@ -29,6 +29,8 @@ export interface CommonViewOptions {
     imageUpload?: ImageUploadOptions;
     /** Externally written plugins to add to the editor */
     externalPlugins?: ExternalEditorPlugin[];
+    /** An optional HTML Element that will be used to show a rendered preview of the post in Markdown-mode */
+    previewTarget?: HTMLElement;
 }
 
 /** Configuration options for parsing and rendering [tag:*] and [meta-tag:*] syntax */


### PR DESCRIPTION
## Background

Okay, this is a controversial one.

Our old editor used a read-only preview pane next to your markdown code. With Stacks-Editor we want to move away from that pattern in favor of having a two-way synchronization between rich-text and markdown mode.

There's been recurring feedback on the meta announcement that a read-only preview when writing markdown would continue to solve a bunch of problems and allow people to stick to a workflow they're used to (see [here](https://meta.stackexchange.com/a/360058/507720), [here](https://meta.stackexchange.com/a/360146/507720) and somewhat buried also [here](https://meta.stackexchange.com/a/360142/507720)).

I know that [every change is going to break someone's workflow](https://xkcd.com/1172/) and it's important to have a clear direction for Stacks-Editor. At the same time, I don't want to dismiss users' concerns and explore what the solution that quite a bunch of people are asking for could look and feel like. So in this PR I've created a (admittedly hacky) version of an expandable read-only preview for Markdown-mode.


## Why, why not?
I can see how a preview pane can tackle a couple of problems:

* Support for Mathjax, Chess notation, Guitar Tabs, and all the other site-specific plugins would be comparably trivial to build into a read-only preview mode. We'll have to build these plugins for rich-text mode in the future, but it'll take some time until we get there. For some users, this could prevent switching to Stacks-Editor because they need these plugins to be there
* People who have strong feelings around the "write markdown on top, see preview below" could continue to do so in Stacks-Editor, making the adoption much more seamless
* We could get rid of supporting our old editor sooner. A read-only pane would give us feature parity to the old editor with one big swoop.

Of course this comes with a bunch of drawbacks:
* this might be confusing for the user experience. You'd have a markdown mode, a read-only preview, a rich-text mode, and ultimately the properly rendered and saved post.
* there's a risk that the preview pane becomes a kludge we rely on instead of building more polished solutions to the problems we're facing
* we end up with the same "endless scrolling" usability issue we've had before

There's a lot of ivory-tower discussion we can have about the benefits and drawbacks but I value working code over theoretical discussions. In this fashion, this PR introduces a read-only preview that's visible in Markdown-mode.

## Features of this spike

* show a read-only preview of your Markdown post below the editor
* hide read-only preview by default, show via toggle. This way, we'd hide the feature in the default experience and let people who explicitly want to have the questionable scrolling experience activate it. We could hook this up to user preferences on Stack Overflow.
* trigger read-only preview synchronization _after_ a user stops typing to prevent multiple costly render operations
* pass preview pane element via the editor options - initialize preview only if a preview element is given

Please note that this is not meant to be production-ready code at all. It comes without tests, I've cut a lot of corners and glossed over obvious bugs for the sake of getting a prototype in place. I encourage people to not focus on the code in this PR but to play around with the prototype instead.

**Check out [the demo](https://deploy-preview-15--nifty-lalande-39c157.netlify.app/)**