### PR TITLE
Fixed issue for two editors and cancelling an image upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1718,6 +1718,7 @@
                 "jest-resolve": "^26.6.2",
                 "jest-util": "^26.6.2",
                 "jest-worker": "^26.6.2",
+                "node-notifier": "^8.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -3577,6 +3578,7 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
+                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -6057,6 +6059,7 @@
             "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
             "dev": true,
             "dependencies": {
+                "@types/yauzl": "^2.9.1",
                 "debug": "^4.1.1",
                 "get-stream": "^5.1.0",
                 "yauzl": "^2.10.0"
@@ -8054,6 +8057,7 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
+                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-regex-util": "^26.0.0",
                 "jest-serializer": "^26.6.2",
@@ -8641,7 +8645,14 @@
             "dev": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "image-size": "~0.5.0",
+                "make-dir": "^2.1.0",
+                "mime": "^1.4.1",
+                "needle": "^2.5.2",
                 "parse-node-version": "^1.0.1",
+                "source-map": "~0.6.0",
                 "tslib": "^1.10.0"
             },
             "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1718,7 +1718,6 @@
                 "jest-resolve": "^26.6.2",
                 "jest-util": "^26.6.2",
                 "jest-worker": "^26.6.2",
-                "node-notifier": "^8.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -3578,7 +3577,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -6059,7 +6057,6 @@
             "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
             "dev": true,
             "dependencies": {
-                "@types/yauzl": "^2.9.1",
                 "debug": "^4.1.1",
                 "get-stream": "^5.1.0",
                 "yauzl": "^2.10.0"
@@ -8057,7 +8054,6 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-regex-util": "^26.0.0",
                 "jest-serializer": "^26.6.2",
@@ -8645,14 +8641,7 @@
             "dev": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
-                "errno": "^0.1.1",
-                "graceful-fs": "^4.1.2",
-                "image-size": "~0.5.0",
-                "make-dir": "^2.1.0",
-                "mime": "^1.4.1",
-                "needle": "^2.5.2",
                 "parse-node-version": "^1.0.1",
-                "source-map": "~0.6.0",
                 "tslib": "^1.10.0"
             },
             "bin": {

--- a/site/index.html
+++ b/site/index.html
@@ -169,7 +169,10 @@ And finally, Stack Snippets:
         </textarea>
         <h1>Stacks Editor</h1>
         <h3>Showcasing our new editing experience for Stack Overflow</h3>
-        <div id="example-1"></div>
+        <div class="grid">
+            <div id="example-1" class="mr8"></div>
+            <div id="example-2"></div>
+        </div>
     </div>
 </body>
 

--- a/site/index.html
+++ b/site/index.html
@@ -43,6 +43,9 @@
                 <li class="s-sidebarwidget--item">
                     <a href="./tables.html" class="s-link">Tables playground</a>
                 </li>
+                <li class="s-sidebarwidget--item">
+                    <a href="./dualeditor.html" class="s-link">Dual editor playground</a>
+                </li>
             </ul>
         </div>
     </div>
@@ -169,10 +172,7 @@ And finally, Stack Snippets:
         </textarea>
         <h1>Stacks Editor</h1>
         <h3>Showcasing our new editing experience for Stack Overflow</h3>
-        <div class="grid">
-            <div id="example-1" class="mr8"></div>
-            <div id="example-2"></div>
-        </div>
+        <div id="example-1"></div>
     </div>
 </body>
 

--- a/site/index.ts
+++ b/site/index.ts
@@ -1,4 +1,5 @@
 import type { StacksEditor } from "../src";
+import type { StacksEditorOptions } from "../src";
 import { StackSnippetsPlugin } from "../src/external-plugins/stack-snippets";
 import type { LinkPreviewProvider } from "../src/rich-text/plugins/link-preview";
 import type { ImageUploadOptions } from "../src/shared/prosemirror-plugins/image-upload";
@@ -113,6 +114,7 @@ domReady(() => {
 
     // create the editor
     const place = document.querySelector<HTMLElement>("#example-1");
+    const place2 = document.querySelector<HTMLElement>("#example-2");
     const content = document.querySelector<HTMLTextAreaElement>("#content");
     const enableTables = place.classList.contains("js-tables-enabled");
     const enableImages = !place.classList.contains("js-images-disabled");
@@ -133,7 +135,7 @@ domReady(() => {
 
     // asynchronously load the required bundles
     void import("../src/index").then(function ({ StacksEditor }) {
-        const editorInstance = new StacksEditor(place, content.value, {
+        const options: StacksEditorOptions = {
             defaultView: getDefaultEditor(),
             editorHelpLink: "#TODO",
             commonmarkOptions: {},
@@ -159,13 +161,33 @@ domReady(() => {
             },
             imageUpload: imageUploadOptions,
             externalPlugins: [StackSnippetsPlugin],
-        });
+        };
+
+        const editorInstance = new StacksEditor(place, content.value, options);
+
         // set the instance on the window for developers to poke around in
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
         (window as any)["editorInstance"] = editorInstance;
+
+        const secondEditorInstance = new StacksEditor(
+            place2,
+            content.value,
+            options
+        );
+
+        // set the instance on the window for developers to poke around in
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        (window as any)["secondEditorInstance"] = secondEditorInstance;
     });
 
     place.addEventListener(
+        "StacksEditor:view-change",
+        (e: CustomEvent<{ editorType: number }>) => {
+            setDefaultEditor(e.detail.editorType);
+        }
+    );
+
+    place2.addEventListener(
         "StacksEditor:view-change",
         (e: CustomEvent<{ editorType: number }>) => {
             setDefaultEditor(e.detail.editorType);

--- a/site/index.ts
+++ b/site/index.ts
@@ -169,15 +169,14 @@ domReady(() => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
         (window as any)["editorInstance"] = editorInstance;
 
-        const secondEditorInstance = new StacksEditor(
-            place2,
-            content.value,
-            options
-        );
+        if ( place2 != null)
+        {
+            const secondEditorInstance = new StacksEditor(place2, content.value, options);
 
-        // set the instance on the window for developers to poke around in
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-        (window as any)["secondEditorInstance"] = secondEditorInstance;
+            // set the instance on the window for developers to poke around in
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+            (window as any)["secondEditorInstance"] = secondEditorInstance;
+        }
     });
 
     place.addEventListener(
@@ -187,7 +186,7 @@ domReady(() => {
         }
     );
 
-    place2.addEventListener(
+    place2?.addEventListener(
         "StacksEditor:view-change",
         (e: CustomEvent<{ editorType: number }>) => {
             setDefaultEditor(e.detail.editorType);

--- a/site/index.ts
+++ b/site/index.ts
@@ -169,7 +169,7 @@ domReady(() => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
         (window as any)["editorInstance"] = editorInstance;
 
-        if ( place2 != null)
+        if (place2)
         {
             const secondEditorInstance = new StacksEditor(place2, content.value, options);
 

--- a/site/variants/dualeditor.html
+++ b/site/variants/dualeditor.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Stacks Editor</title>
+    <link rel="icon"
+        href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐸</text></svg>" />
+    <link rel="stylesheet" href="https://unpkg.com/@stackoverflow/stacks/dist/css/stacks.min.css" />
+    <script src="https://unpkg.com/@stackoverflow/stacks/dist/js/stacks.min.js"></script>
+</head>
+
+<body class="p24">
+    <form class="wmx6 m-auto">
+        <textarea id="content" name="content" class="d-none"></textarea>
+        <h1 class="mt32">Dual Editor Playground</h1>
+        <div class="grid">
+            <div id="example-1" class="mr8"></div>
+            <div id="example-2"></div>
+        </div>
+    </form>
+</body>
+
+</html>

--- a/site/variants/dualeditor.html
+++ b/site/variants/dualeditor.html
@@ -15,8 +15,8 @@
     <form class="wmx6 m-auto">
         <textarea id="content" name="content" class="d-none"></textarea>
         <h1 class="mt32">Dual Editor Playground</h1>
-        <div class="grid">
-            <div id="example-1" class="mr8"></div>
+        <div class="grid fd-column">
+            <div id="example-1" class="mb8"></div>
             <div id="example-2"></div>
         </div>
     </form>

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -359,6 +359,8 @@ export class ImageUploader implements PluginView {
     resetUploader(): void {
         this.resetImagePreview();
         this.hideValidationError();
+
+        this.uploadField.value = null;
     }
 
     handleUploadTrigger(event: Event, file: File, view: EditorView): void {
@@ -459,7 +461,6 @@ export class ImageUploader implements PluginView {
 
         this.isVisible = isVisible;
         this.image = state?.file || this.image;
-        this.uploadField.value = null;
 
         if (this.isVisible) {
             this.uploadContainer.classList.remove("d-none");

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -116,7 +116,7 @@ export class ImageUploader implements PluginView {
         this.uploadField.className = "d-none";
         this.uploadField.accept = "image/*";
         this.uploadField.multiple = false;
-        this.uploadField.id = "fileUpload";
+        this.uploadField.id = "fileUpload" + (Math.random() * 10000).toFixed(0);
 
         this.uploadContainer.innerHTML = escapeHTML`
             <div class="fs-body2 p12 pb0"><label class="s-link" for="${this.uploadField.id}">Browse</label>, drag & drop, or paste an image <span class="fc-light fs-caption">Max size 2 MiB</span></div>
@@ -459,6 +459,7 @@ export class ImageUploader implements PluginView {
 
         this.isVisible = isVisible;
         this.image = state?.file || this.image;
+        this.uploadField.value = null;
 
         if (this.isVisible) {
             this.uploadContainer.classList.remove("d-none");


### PR DESCRIPTION
This pull request fixes issues #65 and #66.

#65 is solved by clearing the `uploadField.value `when switching between visible <--> invisible 
#66 is solved by making the `uploadField.id `unique per editor

For #66, I've added a second editor to the test page.
