### PR TITLE
Count characters in the editor content

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -173,6 +173,7 @@ And finally, Stack Snippets:
         <h1>Stacks Editor</h1>
         <h3>Showcasing our new editing experience for Stack Overflow</h3>
         <div id="example-1"></div>
+        <div id="character-count"></div>
     </div>
 </body>
 

--- a/site/index.ts
+++ b/site/index.ts
@@ -138,7 +138,9 @@ domReady(() => {
         const options: StacksEditorOptions = {
             defaultView: getDefaultEditor(),
             editorHelpLink: "#TODO",
-            commonmarkOptions: {},
+            commonmarkOptions: {
+                countCharacters: true,
+            },
             parserFeatures: {
                 tables: enableTables,
                 tagLinks: {
@@ -183,6 +185,15 @@ domReady(() => {
         "StacksEditor:view-change",
         (e: CustomEvent<{ editorType: number }>) => {
             setDefaultEditor(e.detail.editorType);
+        }
+    );
+
+    place.addEventListener(
+        "StacksEditor:char-count-updated",
+        (e: CustomEvent<{ count: number }>) => {
+            document.querySelector(
+                "#character-count"
+            ).textContent = `${e.detail.count} characters`;
         }
     );
 

--- a/src/shared/view.ts
+++ b/src/shared/view.ts
@@ -29,6 +29,8 @@ export interface CommonViewOptions {
     imageUpload?: ImageUploadOptions;
     /** Externally written plugins to add to the editor */
     externalPlugins?: ExternalEditorPlugin[];
+    /** Fire an event when the content length may have changed */
+    countCharacters?: boolean;
 }
 
 /** Configuration options for parsing and rendering [tag:*] and [meta-tag:*] syntax */

--- a/src/stacks-editor/editor.ts
+++ b/src/stacks-editor/editor.ts
@@ -291,6 +291,22 @@ export class StacksEditor implements View {
             },
         };
 
+        this.backingView.editorView.props.dispatchTransaction = (tr) => {
+            this.editorView.updateState(this.editorView.state.apply(tr));
+
+            if (this.options.commonmarkOptions.countCharacters) {
+                const event = new CustomEvent(
+                    this.prefixEventName("char-count-updated"),
+                    {
+                        detail: {
+                            count: this.content.length,
+                        },
+                    }
+                );
+                this.target.dispatchEvent(event);
+            }
+        };
+
         // re-sync the view readonly state / classes
         if (readonly) {
             this.disable();


### PR DESCRIPTION
I'm going back and forth on firing an event vs letting the editor do something with the count itself. 

For now, I think this is a bit better for my purposes because it'll let me provide localization and SO-specific event handling at the point where I'll be consuming this. On the other hand, I can also envision some sort of UI built into the editor in the future that accepts additional configuration (e.g. min and max number of allowed characters) and does something fancy with styling.

There may still some quirks with the actual counting. As far as I can tell, this *should* be counting using Markdown rather than HTML, but more testing is needed. For that matter, automated tests are missing and will be added soon assuming we all agree that this approach makes sense in the first place.