### PR TITLE
Switch away from deprecated grid classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@stackoverflow/stacks-editor",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@stackoverflow/stacks": "^0.65.1",

--- a/src/external-plugins/stack-snippets.ts
+++ b/src/external-plugins/stack-snippets.ts
@@ -35,7 +35,7 @@ class StackSnippetsView implements NodeView {
      data-console="${this.state.console.toString()}"
      data-babel="${this.state.babel.toString()}">
     <div class="s-link-preview--header ai-center py4">
-        <div class="s-link-preview--title fs-body1 fl1">Code snippet</div>
+        <div class="s-link-preview--title fs-body1 fl-grow1">Code snippet</div>
         <div>
             <button class="s-btn s-btn__muted fc-success s-btn__icon s-btn__xs grid--cell js-not-implemented" title="Run code snippet">
                 <span class="icon-bg iconPlay"></span>

--- a/src/shared/menu.ts
+++ b/src/shared/menu.ts
@@ -31,7 +31,7 @@ class MenuView implements PluginView {
         );
 
         this.dom = document.createElement("div");
-        this.dom.className = "grid gs2 mln4 fl1 ai-center js-editor-menu";
+        this.dom.className = "grid gs2 mln4 fl-grow1 ai-center js-editor-menu";
         this.items.forEach(({ dom }) => this.dom.appendChild(dom));
 
         this.update(view, null);

--- a/src/stacks-editor/editor.ts
+++ b/src/stacks-editor/editor.ts
@@ -110,7 +110,7 @@ export class StacksEditor implements View {
 
     static get defaultOptions(): StacksEditorOptions {
         const commonClasses = [
-            "fl1",
+            "fl-grow1",
             "outline-none",
             "p12",
             "pt6",


### PR DESCRIPTION
`fl1` is getting replaced by the more explicit `fl-grow1` :v: