### PR TITLE
Bump Stacks to 0.66.0 and switch from deprecated grid classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "@stackoverflow/stacks": "^0.65.1",
+                "@stackoverflow/stacks": "^0.66.0",
                 "@stackoverflow/stacks-icons": "^2.20.0",
                 "@types/markdown-it": "10.0.2",
                 "@types/prosemirror-commands": "^1.0.4",
@@ -2328,9 +2328,9 @@
             }
         },
         "node_modules/@stackoverflow/stacks": {
-            "version": "0.65.1",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-0.65.1.tgz",
-            "integrity": "sha512-4X6xaB0UEE3owpchm+5nEq6VAjKmo5q4sqO5TstwGEBVg8yEHn7L+ZvKYxhSYXBFTHtOFqPeng7xhKTDnTj1oQ==",
+            "version": "0.66.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-0.66.0.tgz",
+            "integrity": "sha512-S+3lMwfFwsR8sUTQ/Gp1292TSvF8vPPcoiLdSCjLiv2pEIkaJJVuy2Lu/hCRfpkXnMqHtzIeoUihI/dnqanNOQ==",
             "dependencies": {
                 "@popperjs/core": "^2.9.2",
                 "stimulus": "^1.1.1"
@@ -18821,9 +18821,9 @@
             }
         },
         "@stackoverflow/stacks": {
-            "version": "0.65.1",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-0.65.1.tgz",
-            "integrity": "sha512-4X6xaB0UEE3owpchm+5nEq6VAjKmo5q4sqO5TstwGEBVg8yEHn7L+ZvKYxhSYXBFTHtOFqPeng7xhKTDnTj1oQ==",
+            "version": "0.66.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-0.66.0.tgz",
+            "integrity": "sha512-S+3lMwfFwsR8sUTQ/Gp1292TSvF8vPPcoiLdSCjLiv2pEIkaJJVuy2Lu/hCRfpkXnMqHtzIeoUihI/dnqanNOQ==",
             "requires": {
                 "@popperjs/core": "^2.9.2",
                 "stimulus": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "webpack-merge": "^5.7.3"
     },
     "dependencies": {
-        "@stackoverflow/stacks": "^0.65.1",
+        "@stackoverflow/stacks": "^0.66.0",
         "@stackoverflow/stacks-icons": "^2.20.0",
         "@types/markdown-it": "10.0.2",
         "@types/prosemirror-commands": "^1.0.4",

--- a/site/index.html
+++ b/site/index.html
@@ -20,19 +20,19 @@
         <div class="s-popover" id="js-settings-popover" role="menu">
             <div class="s-popover--arrow"></div>
             <ul class="s-sidebarwidget--content s-sidebarwidget__items btw0 p0">
-                <li class="grid ai-center s-sidebarwidget--item">
-                    <div class="grid--cell s-toggle-switch">
+                <li class="d-flex ai-center s-sidebarwidget--item">
+                    <div class="flex--item s-toggle-switch">
                         <input id="js-toggle-dark" type="checkbox" />
                         <div class="s-toggle-switch--indicator"></div>
                     </div>
-                    <label for="js-toggle-dark" class="grid--cell ml4">Dark mode</label>
+                    <label for="js-toggle-dark" class="flex--item ml4">Dark mode</label>
                 </li>
-                <li class="grid ai-center s-sidebarwidget--item">
-                    <div class="grid--cell s-toggle-switch">
+                <li class="d-flex ai-center s-sidebarwidget--item">
+                    <div class="flex--item s-toggle-switch">
                         <input id="js-toggle-readonly" type="checkbox" />
                         <div class="s-toggle-switch--indicator"></div>
                     </div>
-                    <label for="js-toggle-readonly" class="grid--cell ml4">Readonly</label>
+                    <label for="js-toggle-readonly" class="flex--item ml4">Readonly</label>
                 </li>
                 <li class="s-sidebarwidget--item">
                     <a href="./empty.html" class="s-link">Empty editor</a>

--- a/site/variants/dualeditor.html
+++ b/site/variants/dualeditor.html
@@ -15,7 +15,7 @@
     <form class="wmx6 m-auto">
         <textarea id="content" name="content" class="d-none"></textarea>
         <h1 class="mt32">Dual Editor Playground</h1>
-        <div class="grid fd-column">
+        <div class="d-flex fd-column">
             <div id="example-1" class="mb8"></div>
             <div id="example-2"></div>
         </div>

--- a/src/external-plugins/stack-snippets.ts
+++ b/src/external-plugins/stack-snippets.ts
@@ -37,10 +37,10 @@ class StackSnippetsView implements NodeView {
     <div class="s-link-preview--header ai-center py4">
         <div class="s-link-preview--title fs-body1 fl-grow1">Code snippet</div>
         <div>
-            <button class="s-btn s-btn__muted fc-success s-btn__icon s-btn__xs grid--cell js-not-implemented" title="Run code snippet">
+            <button class="s-btn s-btn__muted fc-success s-btn__icon s-btn__xs flex--item js-not-implemented" title="Run code snippet">
                 <span class="icon-bg iconPlay"></span>
             </button>
-            <button class="s-btn s-btn__muted s-btn__icon s-btn__xs grid--cell js-not-implemented" title="Expand snippet">
+            <button class="s-btn s-btn__muted s-btn__icon s-btn__xs flex--item js-not-implemented" title="Expand snippet">
                 <span class="icon-bg iconShare"></span>
             </button>
         </div>

--- a/src/rich-text/node-views/image.ts
+++ b/src/rich-text/node-views/image.ts
@@ -94,19 +94,19 @@ export class ImageView implements NodeView {
 
     private createForm(): HTMLFormElement {
         const form = document.createElement("form");
-        form.className = "grid fd-column";
+        form.className = "d-flex fd-column";
         form.innerHTML = escapeHTML`
-            <label class="grid--cell s-label mb4" for="img-src-${this.id}">Image source</label>
-            <div class="grid ps-relative mb12">
-                <input class="grid--cell s-input" type="text" name="src" id="img-src-${this.id}" value="${this.img.src}" placeholder="https://example.com/image.png"/>
+            <label class="flex--item s-label mb4" for="img-src-${this.id}">Image source</label>
+            <div class="d-flex ps-relative mb12">
+                <input class="flex--item s-input" type="text" name="src" id="img-src-${this.id}" value="${this.img.src}" placeholder="https://example.com/image.png"/>
             </div>
-            <label class="grid--cell s-label mb4" for="img-alt-${this.id}">Image description</label>
-            <div class="grid ps-relative mb12">
-                <input class="grid--cell s-input" type="text" name="alt" id="img-alt-${this.id}" value="${this.img.alt}" placeholder="A description for the image"/>
+            <label class="flex--item s-label mb4" for="img-alt-${this.id}">Image description</label>
+            <div class="d-flex ps-relative mb12">
+                <input class="flex--item s-input" type="text" name="alt" id="img-alt-${this.id}" value="${this.img.alt}" placeholder="A description for the image"/>
             </div>
-            <label class="grid--cell s-label mb4" for="img-title-${this.id}">Title</label>
-            <div class="grid ps-relative mb12">
-                <input class="grid--cell s-input" type="text" name="title" id="img-title-${this.id}" value="${this.img.title}" placeholder="A title shown on hover"/>
+            <label class="flex--item s-label mb4" for="img-title-${this.id}">Title</label>
+            <div class="d-flex ps-relative mb12">
+                <input class="flex--item s-input" type="text" name="title" id="img-title-${this.id}" value="${this.img.title}" placeholder="A title shown on hover"/>
             </div>
 
             <button class="s-btn s-btn__primary" type="submit" aria-pressed="false">Apply</button>

--- a/src/rich-text/plugins/link-tooltip.ts
+++ b/src/rich-text/plugins/link-tooltip.ts
@@ -52,12 +52,12 @@ class LinkTooltip {
             id="link-tooltip-popover"
             role="menu">
             <div class="s-popover--arrow"></div>
-            <div class="grid ai-center">
+            <div class="d-flex ai-center">
                 <a href="${this.href}"
-                    class="wmx3 grid--cell fs-body1 fw-normal d-inline-block truncate ml8 mr4"
+                    class="wmx3 flex--item fs-body1 fw-normal truncate ml8 mr4"
                     target="_blank"
                     rel="nofollow noreferrer">${this.href}</a>
-                <div class="grid--cell d-none wmn2 ml2 mr4 mb0 js-link-tooltip-input-wrapper">
+                <div class="flex--item d-none wmn2 ml2 mr4 mb0 js-link-tooltip-input-wrapper">
                     <input type="text"
                             class="s-input s-input__sm js-link-tooltip-input"
                             autocomplete="off"
@@ -65,13 +65,13 @@ class LinkTooltip {
                             value="${this.href}" />
                 </div>
                 <button type="button"
-                        class="grid--cell s-btn mr4 js-link-tooltip-edit"
+                        class="flex--item s-btn mr4 js-link-tooltip-edit"
                         title="${"Edit link"}"><span class="svg-icon icon-bg iconPencilSm"></span></button>
                 <button type="button"
-                        class="grid--cell s-btn d-none js-link-tooltip-apply"
+                        class="flex--item s-btn d-none js-link-tooltip-apply"
                         title="${"Apply new link"}">${"Apply"}</button>
                 <button type="button"
-                        class="grid--cell s-btn js-link-tooltip-remove"
+                        class="flex--item s-btn js-link-tooltip-remove"
                         title="${"Remove link"}"><span class="svg-icon icon-bg iconTrashSm"></span></button>
             </div>
         </div>`;

--- a/src/shared/menu.ts
+++ b/src/shared/menu.ts
@@ -31,7 +31,7 @@ class MenuView implements PluginView {
         );
 
         this.dom = document.createElement("div");
-        this.dom.className = "grid gs2 mln4 fl-grow1 ai-center js-editor-menu";
+        this.dom.className = "d-flex gs2 mln4 fl-grow1 ai-center js-editor-menu";
         this.items.forEach(({ dom }) => this.dom.appendChild(dom));
 
         this.update(view, null);
@@ -215,7 +215,7 @@ export function makeMenuIcon(
     cssClasses?: string[]
 ): HTMLButtonElement {
     const button = document.createElement("button");
-    button.className = `s-editor-btn grid--cell js-editor-btn js-${key}`;
+    button.className = `s-editor-btn flex--item js-editor-btn js-${key}`;
 
     if (cssClasses) {
         button.classList.add(...cssClasses);
@@ -244,7 +244,7 @@ export function makeMenuSpacerEntry(
     cssClasses?: string[]
 ): MenuCommandEntry {
     const dom = document.createElement("div");
-    dom.className = "grid--cell w16";
+    dom.className = "flex--item w16";
 
     if (cssClasses) {
         dom.classList.add(...cssClasses);
@@ -294,7 +294,7 @@ export function makeMenuDropdown(
     popover.appendChild(arrow);
 
     const content = document.createElement("div");
-    content.className = "grid fd-column";
+    content.className = "d-flex fd-column";
 
     content.append(...children.map((c) => c.dom));
     popover.appendChild(content);
@@ -325,7 +325,7 @@ export function dropdownItem(
 ): MenuCommandEntry {
     const button = document.createElement("button");
     button.type = "button";
-    button.className = `s-btn s-btn__unset grid--cell ta-left px12 py4 h:bg-black-050 c-pointer js-editor-btn`;
+    button.className = `s-btn s-btn__unset flex--item ta-left px12 py4 h:bg-black-050 c-pointer js-editor-btn`;
     button.dataset.key = key;
     button.textContent = title;
 
@@ -344,7 +344,7 @@ export function dropdownItem(
  */
 export function dropdownSection(title: string, key: string): MenuCommandEntry {
     const section = document.createElement("span");
-    section.className = `grid--cell ta-left fs-fine tt-uppercase mx12 mb6 mt12 fc-black-400`;
+    section.className = `flex--item ta-left fs-fine tt-uppercase mx12 mb6 mt12 fc-black-400`;
     section.dataset.key = key;
     section.textContent = title;
 
@@ -369,7 +369,7 @@ export function makeMenuLinkEntry(
     href: string
 ): MenuCommandEntry {
     const dom = document.createElement("a");
-    dom.className = `s-editor-btn js-editor-btn grid--cell`;
+    dom.className = `s-editor-btn js-editor-btn flex--item`;
     dom.href = href;
     dom.target = "_blank";
     dom.title = title;

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -124,10 +124,10 @@ export class ImageUploader implements PluginView {
             <div class="js-image-preview wmx100 pt12 px12 d-none"></div>
             <aside class="s-notice s-notice__warning d-none m8 js-validation-message" role="status" aria-hidden="true"></aside>
 
-            <div class="grid ai-center p12">
+            <div class="d-flex ai-center p12">
                 <button class="s-btn s-btn__primary ws-nowrap mr8 js-add-image" type="button" disabled>Add image</button>
                 <button class="s-btn ws-nowrap js-cancel-button" type="button">Cancel</button>
-                <div class="ml64 grid fd-column fs-caption fc-black-300 s-anchors s-anchors__muted">
+                <div class="ml64 d-flex fd-column fs-caption fc-black-300 s-anchors s-anchors__muted">
                     <div class="js-branding-html"></div>
                     <div class="js-content-policy-html"></div>
                 </div>
@@ -535,10 +535,10 @@ function createPlaceholder(): HTMLDivElement {
     const placeholder = document.createElement("div");
     placeholder.className = "ws-normal d-block m8";
     placeholder.innerHTML = `
-<div class="py6 px12 bg-black-050 bar-sm grid gsx gs8 d-inline-flex ai-center fw-normal fs-body1">
+<div class="py6 px12 bg-black-050 bar-sm gsx gs8 d-inline-flex ai-center fw-normal fs-body1">
     <span class="icon-bg iconImage"></span>
-    <div class="grid--cell">Uploading image</div>
-    <div class="s-spinner s-spinner__sm grid--cell">
+    <div class="flex--item">Uploading image</div>
+    <div class="s-spinner s-spinner__sm flex--item">
         <div class="v-visible-sr">Loading…</div>
     </div>
 </div>

--- a/src/stacks-editor/editor.ts
+++ b/src/stacks-editor/editor.ts
@@ -206,7 +206,7 @@ export class StacksEditor implements View {
 
         // create specific area for the editor menu
         const menuTarget = document.createElement("div");
-        menuTarget.className = "grid overflow-x-auto ai-center px12 py4 pb0";
+        menuTarget.className = "d-flex overflow-x-auto ai-center px12 py4 pb0";
         this.pluginContainer.appendChild(menuTarget);
 
         // set the editors' menu containers to be the combo container
@@ -309,14 +309,14 @@ export class StacksEditor implements View {
             defaultItem === EditorType.Commonmark ? "checked" : "";
 
         const container = document.createElement("div");
-        container.className = "grid--cell grid ai-center ml24 fc-medium";
+        container.className = "d-flex ai-center ml24 fc-medium";
 
         // TODO localization
-        container.innerHTML = escapeHTML`<label class="grid--cell fs-caption mr4 sm:d-none" for="js-editor-toggle-${this.internalId}">Markdown</label>
-            <label class="grid--cell mr4 d-none sm:d-block" for="js-editor-toggle-${this.internalId}">
+        container.innerHTML = escapeHTML`<label class="flex--item fs-caption mr4 sm:d-none" for="js-editor-toggle-${this.internalId}">Markdown</label>
+            <label class="flex--item mr4 d-none sm:d-block" for="js-editor-toggle-${this.internalId}">
                 <span class="icon-bg iconMarkdown"></span>
             </label>
-            <div class="grid--cell s-toggle-switch js-editor-mode-switcher">
+            <div class="flex--item s-toggle-switch js-editor-mode-switcher">
                 <input class="js-editor-toggle-state" id="js-editor-toggle-${this.internalId}" type="checkbox" ${checkedProp}/>
                 <div class="s-toggle-switch--indicator"></div>
             </div>`;


### PR DESCRIPTION
This bumps Stacks to `0.66.0` and swaps from `.grid` and `.grid--cell` to `.d-flex` and `.flex--item`