### PR TITLE
Do not autolink emails without the "mailto:" prefix

### DIFF
--- a/src/shared/markdown-parser.ts
+++ b/src/shared/markdown-parser.ts
@@ -256,8 +256,10 @@ export function buildMarkdownParser(
         defaultMarkdownItInstance.disable("strikethrough");
     }
 
-    // disable autolinking of anything that comes without protocol prefix (e.g. https://)
-    defaultMarkdownItInstance.linkify.set({ fuzzyLink: false });
+    defaultMarkdownItInstance.linkify.set({
+        fuzzyLink: false, // disable autolinking of anything that comes without protocol prefix (e.g. https://)
+        fuzzyEmail: false // disable email autolinking, see this MSE question: https://meta.stackexchange.com/q/370235
+    });
 
     // use a custom link validator that's closer to Stack Overflow's backend validation
     defaultMarkdownItInstance.validateLink = validateLink;

--- a/test/shared/markdown-parser.test.ts
+++ b/test/shared/markdown-parser.test.ts
@@ -283,7 +283,12 @@ console.log("test");
             expect(doc.content[0].content[0].marks[0].type).toBe("link");
         });
 
-        it.each(["file://invalid", "://inherit_scheme.com", "invalid.com"])(
+        it.each([
+            "file://invalid",
+            "://inherit_scheme.com",
+            "invalid.com",
+            "test@example.com"
+        ])(
             "should not autolink invalid links (%s)",
             (input) => {
                 const doc = markdownParser.parse(input).toJSON();


### PR DESCRIPTION
See: [Emails are autolinked in the new Stacks editor](https://meta.stackexchange.com/q/370235) on MSE.