### PR TITLE
feat(options): add option for default validate link to use markdown-it validate link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@stackoverflow/stacks-editor",
+    "name": "@microsoft/stacks-editor",
     "version": "0.4.1",
     "description": "",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/stacks-editor",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "description": "",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/stacks-editor",
-    "version": "0.4.1",
+    "version": "0.4.4",
     "description": "",
     "repository": {
         "type": "git",

--- a/site/index.ts
+++ b/site/index.ts
@@ -157,6 +157,7 @@ domReady(() => {
                         };
                     },
                 },
+                defaultValidateLink: true,
             },
             richTextOptions: {
                 linkPreviewProviders: [ExampleLinkPreviewProvider],

--- a/src/commonmark/commands.ts
+++ b/src/commonmark/commands.ts
@@ -777,23 +777,22 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                     "horizontal-rule-btn"
                 ),
             },
-            makeMenuSpacerEntry(() => false, ["sm:d-inline-block"]),
-            {
-                key: "undo",
-                command: undo,
-                dom: makeMenuIcon("Undo", "Undo", "undo-btn", [
-                    "sm:d-inline-block",
-                ]),
-                visible: () => false,
-            },
-            {
-                key: "redo",
-                command: redo,
-                dom: makeMenuIcon("Refresh", "Redo", "redo-btn", [
-                    "sm:d-inline-block",
-                ]),
-                visible: () => false,
-            },
+            addIf(
+                {
+                    key: "undo",
+                    command: undo,
+                    dom: makeMenuIcon("Undo", "Undo", "undo-btn"),
+                },
+                options.parserFeatures.undo
+            ),
+            addIf(
+                {
+                    key: "redo",
+                    command: redo,
+                    dom: makeMenuIcon("Refresh", "Redo", "redo-btn"),
+                },
+                options.parserFeatures.redo
+            ),
             makeMenuSpacerEntry(),
             //TODO eventually this will mimic the "help" dropdown in the prod editor
             makeMenuLinkEntry("Help", "Help", options.editorHelpLink),

--- a/src/rich-text/commands.ts
+++ b/src/rich-text/commands.ts
@@ -692,23 +692,22 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                     "horizontal-rule-btn"
                 ),
             },
-            makeMenuSpacerEntry(() => false, ["sm:d-inline-block"]),
-            {
-                key: "undo",
-                command: undo,
-                dom: makeMenuIcon("Undo", "Undo", "undo-btn", [
-                    "sm:d-inline-block",
-                ]),
-                visible: () => false,
-            },
-            {
-                key: "redo",
-                command: redo,
-                dom: makeMenuIcon("Refresh", "Redo", "redo-btn", [
-                    "sm:d-inline-block",
-                ]),
-                visible: () => false,
-            },
+            addIf(
+                {
+                    key: "undo",
+                    command: undo,
+                    dom: makeMenuIcon("Undo", "Undo", "undo-btn"),
+                },
+                options.parserFeatures.undo
+            ),
+            addIf(
+                {
+                    key: "redo",
+                    command: redo,
+                    dom: makeMenuIcon("Refresh", "Redo", "redo-btn"),
+                },
+                options.parserFeatures.redo
+            ),
             makeMenuSpacerEntry(),
             //TODO eventually this will mimic the "help" dropdown in the prod editor
             makeMenuLinkEntry("Help", "Help", options.editorHelpLink),

--- a/src/rich-text/markdown-serializer.ts
+++ b/src/rich-text/markdown-serializer.ts
@@ -140,6 +140,9 @@ const defaultMarkdownSerializerNodes: MarkdownSerializerNodes = {
         let escapedText = state.esc(text, startOfLine);
 
         // built in escape doesn't get all the cases TODO upstream!
+        escapedText = escapedText.replace(/\\\[/g, "[");
+        escapedText = escapedText.replace(/\\\]/g, "]");
+        escapedText = escapedText.replace(/\\:::/g, ":::");
         escapedText = escapedText.replace(/\b_|_\b/g, "\\_");
         escapedText = escapedText.replace(/([<>])/g, "\\$1");
 

--- a/src/shared/markdown-parser.ts
+++ b/src/shared/markdown-parser.ts
@@ -259,9 +259,11 @@ export function buildMarkdownParser(
     // disable autolinking of anything that comes without protocol prefix (e.g. https://)
     defaultMarkdownItInstance.linkify.set({ fuzzyLink: false });
 
-    // use a custom link validator that's closer to Stack Overflow's backend validation
-    defaultMarkdownItInstance.validateLink = validateLink;
-
+    // use the default validate link if defaultValidateLink is set to false
+    if (!features.defaultValidateLink) {
+        // use a custom link validator that's closer to Stack Overflow's backend validation
+        defaultMarkdownItInstance.validateLink = validateLink;
+    }
     // start adding in the parser plugins, NOTE: order matters!
 
     // parse/sanitize html

--- a/src/shared/view.ts
+++ b/src/shared/view.ts
@@ -71,6 +71,8 @@ export interface CommonmarkParserFeatures {
     tagLinks?: TagLinkOptions;
     /** Enable the default link validator from Markdown-It. Else the Stackoverflow validate link function will be used */
     defaultValidateLink?: boolean;
+    undo?: boolean;
+    redo?: boolean;
 }
 
 export const defaultParserFeatures: CommonmarkParserFeatures = {
@@ -82,6 +84,8 @@ export const defaultParserFeatures: CommonmarkParserFeatures = {
         allowMetaTags: true,
         allowNonAscii: false,
     },
+    undo: false,
+    redo: false,
 };
 
 export interface View {

--- a/src/shared/view.ts
+++ b/src/shared/view.ts
@@ -69,6 +69,8 @@ export interface CommonmarkParserFeatures {
     /** Enable tables according to GitHub-flavored markdown */
     tables?: boolean;
     tagLinks?: TagLinkOptions;
+    /** Enable the default link validator from Markdown-It. Else the Stackoverflow validate link function will be used */
+    defaultValidateLink?: boolean;
 }
 
 export const defaultParserFeatures: CommonmarkParserFeatures = {


### PR DESCRIPTION
Added property to `StacksEditorOptions.parserFeatures` option for allowing users to use the default validate link function from Markdown-It to be used instead of the Stack Overflow's validate link method.

- The default Markdown-It option supports data:image along with a few other link types
![image](https://user-images.githubusercontent.com/51799435/138935938-e46ac117-99b1-49d6-9309-d3795effd229.png)
- Stack Overflow's validate link function only supports http links.
![image](https://user-images.githubusercontent.com/51799435/138936023-b0ad4e21-b1be-447f-8940-032160b1aa80.png)

While implementing image uploading functionality for our own project, the usage of data:image URLs are not supported by the Stack Overflow validateLink.