### PR TITLE
fix: add aria-labels to icon-only buttons

### DIFF
--- a/src/shared/menu.ts
+++ b/src/shared/menu.ts
@@ -223,6 +223,7 @@ export function makeMenuIcon(
     }
 
     button.title = title;
+    button.ariaLabel = title;
     button.dataset.controller = "s-tooltip";
     button.dataset.sTooltipPlacement = "top";
     button.dataset.key = key;
@@ -374,6 +375,7 @@ export function makeMenuLinkEntry(
     dom.href = href;
     dom.target = "_blank";
     dom.title = title;
+    dom.ariaLabel = title;
     dom.dataset.controller = "s-tooltip";
     dom.dataset.sTooltipPlacement = "top";
 

--- a/src/shared/menu.ts
+++ b/src/shared/menu.ts
@@ -223,7 +223,7 @@ export function makeMenuIcon(
     }
 
     button.title = title;
-    button.ariaLabel = title;
+    button.setAttribute("aria-label", title);
     button.dataset.controller = "s-tooltip";
     button.dataset.sTooltipPlacement = "top";
     button.dataset.key = key;
@@ -375,7 +375,7 @@ export function makeMenuLinkEntry(
     dom.href = href;
     dom.target = "_blank";
     dom.title = title;
-    dom.ariaLabel = title;
+    dom.setAttribute("aria-label", title);
     dom.dataset.controller = "s-tooltip";
     dom.dataset.sTooltipPlacement = "top";
 


### PR DESCRIPTION
Our icon-only toolbar needs some extra help for accessibility. This PR provides an `aria-label` for each item in the toolbar.