### PR TITLE
docs: add disabled view

### DIFF
--- a/site/index.ts
+++ b/site/index.ts
@@ -136,6 +136,7 @@ domReady(() => {
     const content = document.querySelector<HTMLTextAreaElement>("#content");
     const enableTables = place.classList.contains("js-tables-enabled");
     const enableImages = !place.classList.contains("js-images-disabled");
+    const disableEditor = place.classList.contains("js-editor-disabled");
 
     const imageUploadOptions: ImageUploadOptions = {
         handler: ImageUploadHandler,
@@ -182,6 +183,10 @@ domReady(() => {
         };
 
         const editorInstance = new StacksEditor(place, content.value, options);
+
+        if (disableEditor) {
+            editorInstance.disable();
+        }
 
         // set the instance on the window for developers to poke around in
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any

--- a/site/layout.html
+++ b/site/layout.html
@@ -100,6 +100,11 @@
                         </a>
                     </li>
                     <li class="s-sidebarwidget--item">
+                        <a href="./disabled.html" class="s-link">
+                            Disabled editor
+                        </a>
+                    </li>
+                    <li class="s-sidebarwidget--item">
                         v<span class="js-version-number">???</span>
                     </li>
                 </ul>

--- a/site/views/disabled.html
+++ b/site/views/disabled.html
@@ -1,0 +1,7 @@
+{% layout "layout.html" %} {% block content %}
+<textarea id="content" name="content" class="d-none">
+# Editor Contents
+</textarea>
+<h1 class="mt32">Disabled Editor</h1>
+<div id="example-1" class="js-editor-disabled"></div>
+{% endblock %}


### PR DESCRIPTION
Adding more and more menu options doesn't scale super well, but for now, throwing up an example that'll be up at (after merging)

https://editor.stackoverflow.design/disabled.html

Helps us highlight how the disabled editor works.  In a future ticket / PR - we may want to turn off the markdown toggle on a disabled editor - but maybe not too?