### PR TITLE
Accessibility improvements for the image uploader

### DIFF
--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -120,7 +120,7 @@ export class ImageUploader implements PluginView {
 
         this.uploadContainer.innerHTML = escapeHTML`
             <div class="fs-body2 p12 pb0">
-                <label for="${this.uploadField.id}">
+                <label for="${this.uploadField.id}" class="d-inline-flex">
                     <span class="s-link js-browse-button" role="button" aria-controls="image-preview" tabindex="0">Browse</span>
                 </label>, drag & drop, or paste an image <span class="fc-light fs-caption">Max size 2 MiB</span></div>
 

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -113,15 +113,15 @@ export class ImageUploader implements PluginView {
 
         this.uploadField = document.createElement("input");
         this.uploadField.type = "file";
-        this.uploadField.className = "d-none";
+        this.uploadField.className = "v-visible-sr";
         this.uploadField.accept = "image/*";
         this.uploadField.multiple = false;
         this.uploadField.id = "fileUpload" + (Math.random() * 10000).toFixed(0);
 
         this.uploadContainer.innerHTML = escapeHTML`
             <div class="fs-body2 p12 pb0">
-                <label for="${this.uploadField.id}" class="d-inline-flex">
-                    <span class="s-link js-browse-button" role="button" aria-controls="image-preview" tabindex="0">Browse</span>
+                <label for="${this.uploadField.id}" class="d-inline-flex f:outline-ring s-link js-browse-button" role="button" aria-controls="image-preview">
+                    Browse
                 </label>, drag & drop, or paste an image <span class="fc-light fs-caption">Max size 2 MiB</span></div>
 
             <div id="image-preview" class="js-image-preview wmx100 pt12 px12 d-none"></div>
@@ -138,7 +138,9 @@ export class ImageUploader implements PluginView {
         `;
 
         // add in the uploadField right after the first child element
-        this.uploadContainer.children[0].after(this.uploadField);
+        this.uploadContainer
+            .querySelector(`.js-browse-button`)
+            .appendChild(this.uploadField);
 
         // XSS "safe": this html is passed in via the editor options; it is not our job to sanitize it
         // eslint-disable-next-line no-unsanitized/property
@@ -208,15 +210,6 @@ export class ImageUploader implements PluginView {
             .addEventListener("click", (e: Event) =>
                 this.handleUploadTrigger(e, this.image, view)
             );
-
-        this.uploadContainer
-            .querySelector(".js-browse-button")
-            .addEventListener("keydown", (e: KeyboardEvent) => {
-                if (e.key === "Enter") {
-                    e.preventDefault();
-                    this.uploadField.click();
-                }
-            });
     }
 
     highlightDropArea(event: DragEvent): void {
@@ -348,7 +341,8 @@ export class ImageUploader implements PluginView {
                 image.className = "hmx1 w-auto";
                 image.title = file.name;
                 image.src = reader.result as string;
-                image.alt = "image preview";
+                // TODO localization
+                image.alt = "uploaded image preview";
                 previewElement.appendChild(image);
                 previewElement.classList.remove("d-none");
                 this.image = file;
@@ -479,7 +473,7 @@ export class ImageUploader implements PluginView {
             this.uploadContainer.classList.remove("d-none");
 
             this.uploadContainer
-                .querySelector<HTMLElement>(".js-browse-button")
+                .querySelector<HTMLElement>(".js-browse-button input")
                 .focus();
 
             if (this.image) {

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -119,9 +119,12 @@ export class ImageUploader implements PluginView {
         this.uploadField.id = "fileUpload" + (Math.random() * 10000).toFixed(0);
 
         this.uploadContainer.innerHTML = escapeHTML`
-            <div class="fs-body2 p12 pb0"><label class="s-link" for="${this.uploadField.id}">Browse</label>, drag & drop, or paste an image <span class="fc-light fs-caption">Max size 2 MiB</span></div>
+            <div class="fs-body2 p12 pb0">
+                <label for="${this.uploadField.id}">
+                    <span class="s-link js-browse-button" role="button" aria-controls="image-preview" tabindex="0">Browse</span>
+                </label>, drag & drop, or paste an image <span class="fc-light fs-caption">Max size 2 MiB</span></div>
 
-            <div class="js-image-preview wmx100 pt12 px12 d-none"></div>
+            <div id="image-preview" class="js-image-preview wmx100 pt12 px12 d-none"></div>
             <aside class="s-notice s-notice__warning d-none m8 js-validation-message" role="status" aria-hidden="true"></aside>
 
             <div class="d-flex ai-center p12">
@@ -205,6 +208,15 @@ export class ImageUploader implements PluginView {
             .addEventListener("click", (e: Event) =>
                 this.handleUploadTrigger(e, this.image, view)
             );
+
+        this.uploadContainer
+            .querySelector(".js-browse-button")
+            .addEventListener("keydown", (e: KeyboardEvent) => {
+                if (e.key === "Enter") {
+                    e.preventDefault();
+                    this.uploadField.click();
+                }
+            });
     }
 
     highlightDropArea(event: DragEvent): void {
@@ -464,7 +476,10 @@ export class ImageUploader implements PluginView {
 
         if (this.isVisible) {
             this.uploadContainer.classList.remove("d-none");
-            this.uploadContainer.querySelector("button").focus();
+
+            this.uploadContainer
+                .querySelector<HTMLElement>(".js-browse-button")
+                .focus();
 
             if (this.image) {
                 void this.showImagePreview(this.image);

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -113,7 +113,7 @@ export class ImageUploader implements PluginView {
 
         this.uploadField = document.createElement("input");
         this.uploadField.type = "file";
-        this.uploadField.className = "v-visible-sr";
+        this.uploadField.className = "js-image-uploader-input v-visible-sr";
         this.uploadField.accept = "image/*";
         this.uploadField.multiple = false;
         this.uploadField.id = "fileUpload" + (Math.random() * 10000).toFixed(0);
@@ -473,7 +473,7 @@ export class ImageUploader implements PluginView {
             this.uploadContainer.classList.remove("d-none");
 
             this.uploadContainer
-                .querySelector<HTMLElement>(".js-browse-button input")
+                .querySelector<HTMLElement>(".js-image-uploader-input")
                 .focus();
 
             if (this.image) {

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -348,6 +348,7 @@ export class ImageUploader implements PluginView {
                 image.className = "hmx1 w-auto";
                 image.title = file.name;
                 image.src = reader.result as string;
+                image.alt = "image preview";
                 previewElement.appendChild(image);
                 previewElement.classList.remove("d-none");
                 this.image = file;

--- a/test/shared/plugins/imageUploadPlugin.test.ts
+++ b/test/shared/plugins/imageUploadPlugin.test.ts
@@ -41,6 +41,23 @@ describe("image upload plugin", () => {
         expect(updatedUploadContainer.classList).not.toContain("d-none");
     });
 
+    it("should focus 'browse' button when showing image uploader", () => {
+        // we need to add our DOM to the doc's body in order to make jsdom's "focus" handling work
+        // see https://github.com/jsdom/jsdom/issues/2586#issuecomment-742593116
+        document.body.appendChild(pluginContainer);
+
+        expect(uploader.uploadContainer.classList).toContain("d-none");
+
+        showImageUploader(view.editorView);
+        uploader.update(view.editorView);
+        const updatedUploadContainer =
+            pluginContainer.querySelector(".js-image-uploader");
+
+        expect(document.activeElement).toEqual(
+            updatedUploadContainer.querySelector(".js-browse-button")
+        );
+    });
+
     it("should hide image uploader", () => {
         showImageUploader(view.editorView);
         uploader.update(view.editorView);

--- a/test/shared/plugins/imageUploadPlugin.test.ts
+++ b/test/shared/plugins/imageUploadPlugin.test.ts
@@ -53,9 +53,14 @@ describe("image upload plugin", () => {
         const updatedUploadContainer =
             pluginContainer.querySelector(".js-image-uploader");
 
-        expect(document.activeElement).toEqual(
-            updatedUploadContainer.querySelector(".js-browse-button")
+        const fileInput = updatedUploadContainer.querySelector(
+            ".js-browse-button input"
         );
+        // the actual element changes when the plugin state is updated, so we can't check exact match
+        expect(document.activeElement.className).toEqual(fileInput.className);
+
+        // cleanup the appended child
+        pluginContainer.remove();
     });
 
     it("should hide image uploader", () => {


### PR DESCRIPTION
This PR fixes two accessibility issues on the image uploader:

1. It adds an `alt` text to the preview image after you've selected an image to upload
2. It makes the "browse" button accessible via keyboard (tab navigation), allows triggering the file chooser via keyboard (Enter press on the "browse" button) and automatically focuses the "browse" button once the uploader opens

I'm still unhappy about the outline style used for the browse button. We're using `s-link` under the hood and this is the default style but to me it looks a little out of place. Any ideas?

![Screenshot 2022-03-24 at 14 21 51](https://user-images.githubusercontent.com/491469/159925207-e828ca97-bd2c-444d-bf06-ad98aef12101.png)
