### PR TITLE
fix: treat images as inline

### DIFF
--- a/src/rich-text/node-views/image.ts
+++ b/src/rich-text/node-views/image.ts
@@ -28,7 +28,7 @@ export class ImageView implements NodeView {
 
         this.popover = this.createPopover();
 
-        this.dom = document.createElement("div");
+        this.dom = document.createElement("span");
         this.dom.appendChild(this.img);
         this.dom.appendChild(this.popover);
         this.dom.addEventListener("s-popover:hide", (event: Event) =>


### PR DESCRIPTION
Fixes #53 very simply by rendering images in a `span` instead of a `div`.

I'm fully ready to learn that this is an overly-simple solution but it works fine* AFAICT 🤷‍♂️

---

*It works fine as-in there are no notable regressions. UX is a little lacking in being able move your cursor around freely, but that's a bigger issue and one that I consider out of scope for this  PR.