### PR TITLE
fix: increase button contrast in high contrast mode

### DIFF
--- a/src/styles/custom-components.less
+++ b/src/styles/custom-components.less
@@ -79,16 +79,16 @@
         color: var(--black-700);
     }
 
-    .theme-highcontrast & {
+    .highcontrast-mode({
         color: var(--black-900);
-    }
+    });
 
     &.is-selected,
     &:active {
         color: var(--black-900);
         background-color: var(--black-100);
 
-        .theme-highcontrast & {
+        .highcontrast-mode({
             color: var(--black-050);
             background-color: var(--black-900);
             &:hover {
@@ -97,7 +97,7 @@
             &.s-btn.s-btn__dropdown {
                 border-color: var(--black-900);
             }
-        }
+        });
     }
 
     &.is-disabled {
@@ -107,10 +107,10 @@
             background-color: transparent;
         }
 
-        .theme-highcontrast & {
+        .highcontrast-mode({
             opacity: 0.5;
             color: var(--black-300);
-        }
+        });
     }
 
     &:focus {

--- a/src/styles/custom-components.less
+++ b/src/styles/custom-components.less
@@ -79,10 +79,25 @@
         color: var(--black-700);
     }
 
+    .theme-highcontrast & {
+        color: var(--black-900);
+    }
+
     &.is-selected,
     &:active {
         color: var(--black-900);
         background-color: var(--black-100);
+
+        .theme-highcontrast & {
+            color: var(--black-050);
+            background-color: var(--black-900);
+            &:hover {
+                color: var(--black-050);
+            }
+            &.s-btn.s-btn__dropdown {
+                border-color: var(--black-900);
+            }
+        }
     }
 
     &.is-disabled {
@@ -90,6 +105,11 @@
         cursor: default;
         &:hover {
             background-color: transparent;
+        }
+
+        .theme-highcontrast & {
+            opacity: 0.5;
+            color: var(--black-300);
         }
     }
 


### PR DESCRIPTION
Fixes #86 and adds a few other high contrast enhancements to editor buttons.

Mentioning @allejo for visibility 👋

<details>
<summary>Before</summary>

![light mode high contrast before](https://user-images.githubusercontent.com/647177/166802342-1e49f039-6bfa-4782-820e-5f9e8afe4311.png)
![dark mode high contrast before](https://user-images.githubusercontent.com/647177/166802431-fd047f9d-c293-4bb5-8710-4ff4db8afc1f.png)


</details>

<details>
<summary>After</summary>

![light mode high contrast after](https://user-images.githubusercontent.com/647177/166802806-ac84bf4c-1270-4aff-93b0-b32b65d86079.png)
![dark mode high contrast after](https://user-images.githubusercontent.com/647177/166802860-b15e1cf9-9407-48ec-909f-3bdc677d3aa6.png)

</details>