### PR TITLE
fix: toggle heading only when same level

### DIFF
--- a/src/rich-text/commands/index.ts
+++ b/src/rich-text/commands/index.ts
@@ -73,11 +73,11 @@ function toggleWrapIn(nodeType: NodeType) {
 /** Command to set a block type to a paragraph (plain text) */
 const setToTextCommand = setBlockType(schema.nodes.paragraph);
 
-function toggleBlockType(
+export function toggleBlockType(
     nodeType: NodeType,
     attrs?: { [key: string]: unknown }
 ) {
-    const nodeCheck = nodeTypeActive(nodeType);
+    const nodeCheck = nodeTypeActive(nodeType, attrs);
     const setBlockTypeCommand = setBlockType(nodeType, attrs);
 
     return (state: EditorState, dispatch: (tr: Transaction) => void) => {

--- a/src/rich-text/commands/index.ts
+++ b/src/rich-text/commands/index.ts
@@ -73,6 +73,11 @@ function toggleWrapIn(nodeType: NodeType) {
 /** Command to set a block type to a paragraph (plain text) */
 const setToTextCommand = setBlockType(schema.nodes.paragraph);
 
+/**
+ * Creates a command that toggles the NodeType of the current node to the passed type
+ * @param nodeType The type to toggle to
+ * @param attrs? A key-value map of attributes that must be present on this node for it to be toggled off
+ */
 export function toggleBlockType(
     nodeType: NodeType,
     attrs?: { [key: string]: unknown }

--- a/test/rich-text/commands/index.test.ts
+++ b/test/rich-text/commands/index.test.ts
@@ -2,6 +2,7 @@ import { EditorState, Transaction } from "prosemirror-state";
 import {
     exitInclusiveMarkCommand,
     insertHorizontalRuleCommand,
+    toggleBlockType
 } from "../../../src/rich-text/commands";
 import { richTextSchema } from "../../../src/rich-text/schema";
 import { applySelection, createState } from "../test-helpers";
@@ -41,8 +42,103 @@ describe("commands", () => {
     describe("toggleBlockType", () => {
         it.todo("should insert a paragraph at the end of the doc");
         it.todo("should not insert a paragraph at the end of the doc");
-        it.todo("should change heading level from 1 to 2");
-        it.todo("should change toggle heading off");
+        it("should replace heading with paragraph", () => {
+            const state = applySelection(
+                createState(
+                    "<h1>heading</h1>",
+                    []
+                ),
+                3
+            );
+            const resolvedNode = state.selection.$from;
+            expect(resolvedNode.node().type.name).toBe("heading");
+
+            const { newState, isValid } = executeTransaction(
+                state,
+                toggleBlockType(richTextSchema.nodes.heading, { level: 1 })
+            );
+
+            expect(isValid).toBeTruthy();
+            expect(newState.doc).toMatchNodeTree({
+                "type.name": "doc",
+                "content": [
+                    {
+                        "type.name": "paragraph",
+                        "childCount": 1,
+                    }
+                ],
+            });
+        });
+        it("should replace paragraph with heading level 1", () => {
+            const state = applySelection(
+                createState(
+                    "<p>paragraph</p>",
+                    []
+                ),
+                3
+            );
+            const resolvedNode = state.selection.$from;
+            expect(resolvedNode.node().type.name).toBe("paragraph");
+
+            const { newState, isValid } = executeTransaction(
+                state,
+                toggleBlockType(richTextSchema.nodes.heading, { level: 1 })
+            );
+
+            expect(isValid).toBeTruthy();
+            expect(newState.doc).toMatchNodeTree({
+                "type.name": "doc",
+                "content": [
+                    {
+                        "type.name": "heading",
+                        "attrs": {
+                            "level": 1,
+                            "markup": '',
+                        },
+                        "childCount": 1,
+                    },
+                    {
+                        "type.name": "paragraph",
+                        "childCount": 0,
+                    }
+                ],
+            });
+        });
+        it("should change heading level from 1 to 2", () => {
+            const state = applySelection(
+                createState(
+                    "<h1>heading</h1>",
+                    []
+                ),
+                3
+            );
+            const resolvedNode = state.selection.$from;
+            expect(resolvedNode.node().type.name).toBe("heading");
+
+            const { newState, isValid } = executeTransaction(
+                state,
+                toggleBlockType(richTextSchema.nodes.heading, { level: 2 })
+            );
+
+            expect(isValid).toBeTruthy();
+            expect(newState.doc).toMatchNodeTree({
+                "type.name": "doc",
+                "content": [
+                    {
+                        "type.name": "heading",
+                        "attrs": {
+                            "level": 2,
+                            "markup": '',
+                        },
+                        "childCount": 1,
+                    },
+                    {
+                        "type.name": "paragraph",
+                        "childCount": 0,
+                    }
+                ],
+            });
+        });
     });
 
     describe("insertHorizontalRuleCommand", () => {

--- a/test/rich-text/commands/index.test.ts
+++ b/test/rich-text/commands/index.test.ts
@@ -41,6 +41,8 @@ describe("commands", () => {
     describe("toggleBlockType", () => {
         it.todo("should insert a paragraph at the end of the doc");
         it.todo("should not insert a paragraph at the end of the doc");
+        it.todo("should change heading level from 1 to 2");
+        it.todo("should change toggle heading off");
     });
 
     describe("insertHorizontalRuleCommand", () => {

--- a/test/rich-text/commands/index.test.ts
+++ b/test/rich-text/commands/index.test.ts
@@ -2,7 +2,7 @@ import { EditorState, Transaction } from "prosemirror-state";
 import {
     exitInclusiveMarkCommand,
     insertHorizontalRuleCommand,
-    toggleBlockType
+    toggleBlockType,
 } from "../../../src/rich-text/commands";
 import { richTextSchema } from "../../../src/rich-text/schema";
 import { applySelection, createState } from "../test-helpers";
@@ -42,12 +42,10 @@ describe("commands", () => {
     describe("toggleBlockType", () => {
         it.todo("should insert a paragraph at the end of the doc");
         it.todo("should not insert a paragraph at the end of the doc");
-        it("should replace heading with paragraph", () => {
+
+        it("should toggle a type off when attributes match", () => {
             const state = applySelection(
-                createState(
-                    "<h1>heading</h1>",
-                    []
-                ),
+                createState("<h1>heading</h1>", []),
                 3
             );
             const resolvedNode = state.selection.$from;
@@ -65,16 +63,14 @@ describe("commands", () => {
                     {
                         "type.name": "paragraph",
                         "childCount": 1,
-                    }
+                    },
                 ],
             });
         });
-        it("should replace paragraph with heading level 1", () => {
+
+        it("should should toggle a type on and set attributes when the NodeType doesn't match", () => {
             const state = applySelection(
-                createState(
-                    "<p>paragraph</p>",
-                    []
-                ),
+                createState("<p>paragraph</p>", []),
                 3
             );
             const resolvedNode = state.selection.$from;
@@ -92,24 +88,22 @@ describe("commands", () => {
                     {
                         "type.name": "heading",
                         "attrs": {
-                            "level": 1,
-                            "markup": '',
+                            level: 1,
+                            markup: "",
                         },
                         "childCount": 1,
                     },
                     {
                         "type.name": "paragraph",
                         "childCount": 0,
-                    }
+                    },
                 ],
             });
         });
-        it("should change heading level from 1 to 2", () => {
+
+        it("should should toggle a type on and set attributes when the NodeType matches", () => {
             const state = applySelection(
-                createState(
-                    "<h1>heading</h1>",
-                    []
-                ),
+                createState("<h1>heading</h1>", []),
                 3
             );
             const resolvedNode = state.selection.$from;
@@ -127,15 +121,15 @@ describe("commands", () => {
                     {
                         "type.name": "heading",
                         "attrs": {
-                            "level": 2,
-                            "markup": '',
+                            level: 2,
+                            markup: "",
                         },
                         "childCount": 1,
                     },
                     {
                         "type.name": "paragraph",
                         "childCount": 0,
-                    }
+                    },
                 ],
             });
         });


### PR DESCRIPTION
Fixes #105

Another simple fix that hopefully is not too naïve. Also added a few tests that hopefully give us good heading-related coverage. Once this PR merges, I'd like to add the remaining tests outlined as `it.todo`s.

### TODO

- [x] Add tests