### PR TITLE
feat: add shortcut labels to tooltips

### DIFF
--- a/src/commonmark/commands.ts
+++ b/src/commonmark/commands.ts
@@ -18,6 +18,7 @@ import {
     showImageUploader,
 } from "../shared/prosemirror-plugins/image-upload";
 import type { CommonViewOptions } from "../shared/view";
+import { getShortcut } from "../shared/utils";
 import { Schema } from "prosemirror-model";
 import { undo, redo } from "prosemirror-history";
 
@@ -712,22 +713,38 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
             {
                 key: "toggleHeading",
                 command: headerCommand,
-                dom: makeMenuIcon("Header", "Heading", "heading-btn"),
+                dom: makeMenuIcon(
+                    "Header",
+                    `Heading (${getShortcut("Mod-h")})`,
+                    "heading-btn"
+                ),
             },
             {
                 key: "togglBold",
                 command: boldCommand,
-                dom: makeMenuIcon("Bold", "Bold", "bold-btn"),
+                dom: makeMenuIcon(
+                    "Bold",
+                    `Bold (${getShortcut("Mod-b")})`,
+                    "bold-btn"
+                ),
             },
             {
                 key: "toggleEmphasis",
                 command: emphasisCommand,
-                dom: makeMenuIcon("Italic", "Italic", "italic-btn"),
+                dom: makeMenuIcon(
+                    "Italic",
+                    `Italic (${getShortcut("Mod-i")})`,
+                    "italic-btn"
+                ),
             },
             {
                 key: "toggleCode",
                 command: inlineCodeCommand,
-                dom: makeMenuIcon("Code", "Inline code", "code-btn"),
+                dom: makeMenuIcon(
+                    "Code",
+                    `Inline Code (${getShortcut("Mod-k")})`,
+                    "code-btn"
+                ),
             },
             addIf(
                 {
@@ -745,19 +762,27 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
             {
                 key: "toggleLink",
                 command: insertLinkCommand,
-                dom: makeMenuIcon("Link", "Insert link", "insert-link-btn"),
+                dom: makeMenuIcon(
+                    "Link",
+                    `Link (${getShortcut("Mod-l")})`,
+                    "insert-link-btn"
+                ),
             },
             {
                 key: "toggleBlockquote",
                 command: blockquoteCommand,
-                dom: makeMenuIcon("Quote", "Blockquote", "blockquote-btn"),
+                dom: makeMenuIcon(
+                    "Quote",
+                    `Blockquote (${getShortcut("Ctrl-q")})`,
+                    "blockquote-btn"
+                ),
             },
             {
                 key: "insertCodeblock",
                 command: insertCodeblockCommand,
                 dom: makeMenuIcon(
                     "Codeblock",
-                    "Insert code block",
+                    `Code block (${getShortcut("Mod-m")})`,
                     "code-block-btn"
                 ),
             },
@@ -767,7 +792,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                     command: insertImageCommand,
                     dom: makeMenuIcon(
                         "Image",
-                        "Insert image",
+                        `Image (${getShortcut("Mod-g")})`,
                         "insert-image-btn"
                     ),
                 },
@@ -779,7 +804,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                     command: insertTableCommand,
                     dom: makeMenuIcon(
                         "Table",
-                        "Insert table",
+                        `Table (${getShortcut("Mod-e")})`,
                         "insert-table-btn"
                     ),
                 },
@@ -791,7 +816,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: orderedListCommand,
                 dom: makeMenuIcon(
                     "OrderedList",
-                    "Numbered list",
+                    `Numbered list (${getShortcut("Mod-o")})`,
                     "numbered-list-btn"
                 ),
             },
@@ -800,7 +825,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: unorderedListCommand,
                 dom: makeMenuIcon(
                     "UnorderedList",
-                    "Bulleted list",
+                    `Bulleted list (${getShortcut("Mod-u")})`,
                     "bullet-list-btn"
                 ),
             },
@@ -809,7 +834,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: insertHorizontalRuleCommand,
                 dom: makeMenuIcon(
                     "HorizontalRule",
-                    "Insert Horizontal rule",
+                    `Horizontal rule (${getShortcut("Mod-r")})`,
                     "horizontal-rule-btn"
                 ),
             },

--- a/src/rich-text/commands/index.ts
+++ b/src/rich-text/commands/index.ts
@@ -25,6 +25,7 @@ import {
 } from "../../shared/prosemirror-plugins/image-upload";
 import { richTextSchema as schema } from "../schema";
 import type { CommonViewOptions } from "../../shared/view";
+import { getShortcut } from "../../shared/utils";
 import { LINK_TOOLTIP_KEY } from "../plugins/link-editor";
 import { insertParagraphIfAtDocEnd } from "./helpers";
 import {
@@ -283,31 +284,6 @@ export function exitInclusiveMarkCommand(
     return true;
 }
 
-/**
- * Returns a string containing the label and readable keyboard shortcut for button tooltips
- * @param label The type to toggle to
- * @param mapping? Corresponding command mapping (keyboard shortcut)
- */
-function getTooltipText(label: string, mapping?: string): string {
-    if (!mapping) {
-        return label;
-    }
-
-    let osSpecificMapping = mapping;
-    // Replaces `Mod-` with the OS-appropriate modifier
-    if (mapping.indexOf("Mod-") === 0) {
-        const isMac = /Mac/.test(navigator.userAgent);
-        osSpecificMapping = mapping.replace("Mod-", isMac ? "Cmd-" : "Ctrl-");
-    }
-
-    const readableMapping = osSpecificMapping
-        .split("-")
-        .join(" + ")
-        .toLowerCase();
-
-    return `${label} (${readableMapping})`;
-}
-
 const tableDropdown = () =>
     makeMenuDropdown(
         "Table",
@@ -346,7 +322,7 @@ const tableDropdown = () =>
 const headingDropdown = () =>
     makeMenuDropdown(
         "Header",
-        getTooltipText("Header", "Mod-h"),
+        `Heading (${getShortcut("Mod-h")})`,
         "heading-dropdown",
         () => true,
         nodeTypeActive(schema.nodes.heading),
@@ -383,7 +359,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: toggleMark(schema.marks.strong),
                 dom: makeMenuIcon(
                     "Bold",
-                    getTooltipText("Bold", "Mod-b"),
+                    `Bold (${getShortcut("Mod-b")})`,
                     "bold-btn"
                 ),
                 active: markActive(schema.marks.strong),
@@ -393,7 +369,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: toggleMark(schema.marks.em),
                 dom: makeMenuIcon(
                     "Italic",
-                    getTooltipText("Italic", "Mod-i"),
+                    `Italic (${getShortcut("Mod-i")})`,
                     "italic-btn"
                 ),
                 active: markActive(schema.marks.em),
@@ -403,7 +379,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: toggleMark(schema.marks.code),
                 dom: makeMenuIcon(
                     "Code",
-                    getTooltipText("Code", "Mod-k"),
+                    `Inline Code (${getShortcut("Mod-k")})`,
                     "code-btn"
                 ),
                 active: markActive(schema.marks.code),
@@ -427,7 +403,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: insertLinkCommand,
                 dom: makeMenuIcon(
                     "Link",
-                    getTooltipText("Link", "Mod-l"),
+                    `Link (${getShortcut("Mod-l")})`,
                     "insert-link-btn"
                 ),
             },
@@ -436,7 +412,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: toggleWrapIn(schema.nodes.blockquote),
                 dom: makeMenuIcon(
                     "Quote",
-                    getTooltipText("Blockquote", "Ctrl-q"),
+                    `Blockquote (${getShortcut("Ctrl-q")})`,
                     "blockquote-btn"
                 ),
                 active: nodeTypeActive(schema.nodes.blockquote),
@@ -446,7 +422,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: toggleBlockType(schema.nodes.code_block),
                 dom: makeMenuIcon(
                     "Codeblock",
-                    getTooltipText("Code block", "Mod-m"),
+                    `Code block (${getShortcut("Mod-m")})`,
                     "code-block-btn"
                 ),
                 active: nodeTypeActive(schema.nodes.code_block),
@@ -457,7 +433,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                     command: insertImageCommand,
                     dom: makeMenuIcon(
                         "Image",
-                        getTooltipText("Image", "Mod-g"),
+                        `Image (${getShortcut("Mod-g")})`,
                         "insert-image-btn"
                     ),
                 },
@@ -469,7 +445,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                     command: insertTableCommand,
                     dom: makeMenuIcon(
                         "Table",
-                        getTooltipText("Table", "Mod-e"),
+                        `Table (${getShortcut("Mod-e")})`,
                         "insert-table-btn"
                     ),
                     visible: (state: EditorState) => !inTable(state.selection),
@@ -483,7 +459,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: toggleWrapIn(schema.nodes.ordered_list),
                 dom: makeMenuIcon(
                     "OrderedList",
-                    getTooltipText("Numbered list", "Mod-o"),
+                    `Numbered list (${getShortcut("Mod-o")})`,
                     "numbered-list-btn"
                 ),
                 active: nodeTypeActive(schema.nodes.ordered_list),
@@ -493,7 +469,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: toggleWrapIn(schema.nodes.bullet_list),
                 dom: makeMenuIcon(
                     "UnorderedList",
-                    getTooltipText("Bulleted list", "Mod-u"),
+                    `Bulleted list (${getShortcut("Mod-u")})`,
                     "bullet-list-btn"
                 ),
                 active: nodeTypeActive(schema.nodes.bullet_list),
@@ -503,7 +479,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: insertHorizontalRuleCommand,
                 dom: makeMenuIcon(
                     "HorizontalRule",
-                    getTooltipText("Horizontal rule", "Mod-r"),
+                    `Horizontal rule (${getShortcut("Mod-r")})`,
                     "horizontal-rule-btn"
                 ),
             },
@@ -511,23 +487,17 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
             {
                 key: "undo",
                 command: undo,
-                dom: makeMenuIcon(
-                    "Undo",
-                    getTooltipText("Undo", "Mod-z"),
-                    "undo-btn",
-                    ["sm:d-inline-block"]
-                ),
+                dom: makeMenuIcon("Undo", "Undo", "undo-btn", [
+                    "sm:d-inline-block",
+                ]),
                 visible: () => false,
             },
             {
                 key: "redo",
                 command: redo,
-                dom: makeMenuIcon(
-                    "Refresh",
-                    getTooltipText("Redo", "Mod-y"),
-                    "redo-btn",
-                    ["sm:d-inline-block"]
-                ),
+                dom: makeMenuIcon("Refresh", "Refresh", "redo-btn", [
+                    "sm:d-inline-block",
+                ]),
                 visible: () => false,
             },
             makeMenuSpacerEntry(),

--- a/src/rich-text/commands/index.ts
+++ b/src/rich-text/commands/index.ts
@@ -487,17 +487,23 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
             {
                 key: "undo",
                 command: undo,
-                dom: makeMenuIcon("Undo", "Undo", "undo-btn", [
-                    "sm:d-inline-block",
-                ]),
+                dom: makeMenuIcon(
+                    "Undo",
+                    `Undo (${getShortcut("Mod-z")})`,
+                    "undo-btn",
+                    ["sm:d-inline-block"]
+                ),
                 visible: () => false,
             },
             {
                 key: "redo",
                 command: redo,
-                dom: makeMenuIcon("Refresh", "Redo", "redo-btn", [
-                    "sm:d-inline-block",
-                ]),
+                dom: makeMenuIcon(
+                    "Refresh",
+                    `Redo (${getShortcut("Mod-y")})`,
+                    "redo-btn",
+                    ["sm:d-inline-block"]
+                ),
                 visible: () => false,
             },
             makeMenuSpacerEntry(),

--- a/src/rich-text/commands/index.ts
+++ b/src/rich-text/commands/index.ts
@@ -283,6 +283,31 @@ export function exitInclusiveMarkCommand(
     return true;
 }
 
+/**
+ * Returns a string containing the label and readable keyboard shortcut for button tooltips
+ * @param label The type to toggle to
+ * @param mapping? Corresponding command mapping (keyboard shortcut)
+ */
+function getTooltipText(label: string, mapping?: string): string {
+    if (!mapping) {
+        return label;
+    }
+
+    let osSpecificMapping = mapping;
+    // Replaces `Mod-` with the OS-appropriate modifier
+    if (mapping.indexOf("Mod-") === 0) {
+        const isMac = /Mac/.test(navigator.userAgent);
+        osSpecificMapping = mapping.replace("Mod-", isMac ? "Cmd-" : "Ctrl-");
+    }
+
+    const readableMapping = osSpecificMapping
+        .split("-")
+        .join(" + ")
+        .toLowerCase();
+
+    return `${label} (${readableMapping})`;
+}
+
 const tableDropdown = () =>
     makeMenuDropdown(
         "Table",
@@ -321,7 +346,7 @@ const tableDropdown = () =>
 const headingDropdown = () =>
     makeMenuDropdown(
         "Header",
-        "Header",
+        getTooltipText("Header", "Mod-h"),
         "heading-dropdown",
         () => true,
         nodeTypeActive(schema.nodes.heading),
@@ -356,19 +381,31 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
             {
                 key: "toggleBold",
                 command: toggleMark(schema.marks.strong),
-                dom: makeMenuIcon("Bold", "Bold", "bold-btn"),
+                dom: makeMenuIcon(
+                    "Bold",
+                    getTooltipText("Bold", "Mod-b"),
+                    "bold-btn"
+                ),
                 active: markActive(schema.marks.strong),
             },
             {
                 key: "toggleEmphasis",
                 command: toggleMark(schema.marks.em),
-                dom: makeMenuIcon("Italic", "Italic", "italic-btn"),
+                dom: makeMenuIcon(
+                    "Italic",
+                    getTooltipText("Italic", "Mod-i"),
+                    "italic-btn"
+                ),
                 active: markActive(schema.marks.em),
             },
             {
                 key: "toggleCode",
                 command: toggleMark(schema.marks.code),
-                dom: makeMenuIcon("Code", "Inline code", "code-btn"),
+                dom: makeMenuIcon(
+                    "Code",
+                    getTooltipText("Code", "Mod-k"),
+                    "code-btn"
+                ),
                 active: markActive(schema.marks.code),
             },
             addIf(
@@ -388,25 +425,41 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
             {
                 key: "toggleLink",
                 command: insertLinkCommand,
-                dom: makeMenuIcon("Link", "Link selection", "insert-link-btn"),
+                dom: makeMenuIcon(
+                    "Link",
+                    getTooltipText("Link", "Mod-l"),
+                    "insert-link-btn"
+                ),
             },
             {
                 key: "toggleBlockquote",
                 command: toggleWrapIn(schema.nodes.blockquote),
-                dom: makeMenuIcon("Quote", "Blockquote", "blockquote-btn"),
+                dom: makeMenuIcon(
+                    "Quote",
+                    getTooltipText("Blockquote", "Ctrl-q"),
+                    "blockquote-btn"
+                ),
                 active: nodeTypeActive(schema.nodes.blockquote),
             },
             {
                 key: "toggleCodeblock",
                 command: toggleBlockType(schema.nodes.code_block),
-                dom: makeMenuIcon("Codeblock", "Code block", "code-block-btn"),
+                dom: makeMenuIcon(
+                    "Codeblock",
+                    getTooltipText("Code block", "Mod-m"),
+                    "code-block-btn"
+                ),
                 active: nodeTypeActive(schema.nodes.code_block),
             },
             addIf(
                 {
                     key: "insertImage",
                     command: insertImageCommand,
-                    dom: makeMenuIcon("Image", "Image", "insert-image-btn"),
+                    dom: makeMenuIcon(
+                        "Image",
+                        getTooltipText("Image", "Mod-g"),
+                        "insert-image-btn"
+                    ),
                 },
                 !!options.imageUpload?.handler
             ),
@@ -414,7 +467,11 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 {
                     key: "insertTable",
                     command: insertTableCommand,
-                    dom: makeMenuIcon("Table", "Table", "insert-table-btn"),
+                    dom: makeMenuIcon(
+                        "Table",
+                        getTooltipText("Table", "Mod-e"),
+                        "insert-table-btn"
+                    ),
                     visible: (state: EditorState) => !inTable(state.selection),
                 },
                 options.parserFeatures.tables
@@ -426,7 +483,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: toggleWrapIn(schema.nodes.ordered_list),
                 dom: makeMenuIcon(
                     "OrderedList",
-                    "Numbered list",
+                    getTooltipText("Numbered list", "Mod-o"),
                     "numbered-list-btn"
                 ),
                 active: nodeTypeActive(schema.nodes.ordered_list),
@@ -436,7 +493,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: toggleWrapIn(schema.nodes.bullet_list),
                 dom: makeMenuIcon(
                     "UnorderedList",
-                    "Bulleted list",
+                    getTooltipText("Bulleted list", "Mod-u"),
                     "bullet-list-btn"
                 ),
                 active: nodeTypeActive(schema.nodes.bullet_list),
@@ -446,7 +503,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
                 command: insertHorizontalRuleCommand,
                 dom: makeMenuIcon(
                     "HorizontalRule",
-                    "Horizontal rule",
+                    getTooltipText("Horizontal rule", "Mod-r"),
                     "horizontal-rule-btn"
                 ),
             },
@@ -454,17 +511,23 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
             {
                 key: "undo",
                 command: undo,
-                dom: makeMenuIcon("Undo", "Undo", "undo-btn", [
-                    "sm:d-inline-block",
-                ]),
+                dom: makeMenuIcon(
+                    "Undo",
+                    getTooltipText("Undo", "Mod-z"),
+                    "undo-btn",
+                    ["sm:d-inline-block"]
+                ),
                 visible: () => false,
             },
             {
                 key: "redo",
                 command: redo,
-                dom: makeMenuIcon("Refresh", "Redo", "redo-btn", [
-                    "sm:d-inline-block",
-                ]),
+                dom: makeMenuIcon(
+                    "Refresh",
+                    getTooltipText("Redo", "Mod-y"),
+                    "redo-btn",
+                    ["sm:d-inline-block"]
+                ),
                 visible: () => false,
             },
             makeMenuSpacerEntry(),

--- a/src/rich-text/commands/index.ts
+++ b/src/rich-text/commands/index.ts
@@ -495,7 +495,7 @@ export const createMenu = (options: CommonViewOptions): Plugin =>
             {
                 key: "redo",
                 command: redo,
-                dom: makeMenuIcon("Refresh", "Refresh", "redo-btn", [
+                dom: makeMenuIcon("Refresh", "Redo", "redo-btn", [
                     "sm:d-inline-block",
                 ]),
                 visible: () => false,

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -213,6 +213,22 @@ export function escapeHTML(
 }
 
 /**
+ * Returns a string containing the label and readable keyboard shortcut for button tooltips
+ * @param label The type to toggle to
+ * @param mapping? Corresponding command mapping (keyboard shortcut)
+ */
+export function getShortcut(mapping?: string): string {
+    if (mapping.indexOf("Mod-") !== 0) {
+        return mapping;
+    }
+
+    return mapping.replace(
+        "Mod-",
+        /Mac/.test(navigator.userAgent) ? "Cmd-" : "Ctrl-"
+    );
+}
+
+/**
  * Prefixes an event name to scope it to the editor
  * e.g. `view-change` becomes `StacksEditor:view-change`
  * @param eventName The event name to prefix

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -224,7 +224,7 @@ export function getShortcut(mapping?: string): string {
 
     return mapping.replace(
         "Mod-",
-        /Mac/.test(navigator.userAgent) ? "Cmd-" : "Ctrl-"
+        /Mac|iP(hone|[oa]d)/.test(navigator.platform) ? "Cmd-" : "Ctrl-"
     );
 }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -222,7 +222,10 @@ export function getShortcut(mapping: string): string {
         return mapping;
     }
 
-    return (/Mac|iP(hone|[oa]d)/.test(navigator.platform) ? "Cmd" : "Ctrl") + mapping.slice(3);
+    return (
+        (/Mac|iP(hone|[oa]d)/.test(navigator.platform) ? "Cmd" : "Ctrl") +
+        mapping.slice(3)
+    );
 }
 
 /**

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -214,8 +214,7 @@ export function escapeHTML(
 
 /**
  * Returns a string containing the label and readable keyboard shortcut for button tooltips
- * @param label The type to toggle to
- * @param mapping? Corresponding command mapping (keyboard shortcut)
+ * @param mapping Corresponding command mapping (keyboard shortcut)
  */
 export function getShortcut(mapping: string): string {
     if (!mapping.startsWith("Mod-")) {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -218,14 +218,11 @@ export function escapeHTML(
  * @param mapping? Corresponding command mapping (keyboard shortcut)
  */
 export function getShortcut(mapping: string): string {
-    if (mapping.indexOf("Mod-") !== 0) {
+    if (!mapping.startsWith("Mod-")) {
         return mapping;
     }
 
-    return mapping.replace(
-        "Mod-",
-        /Mac|iP(hone|[oa]d)/.test(navigator.platform) ? "Cmd-" : "Ctrl-"
-    );
+    return (/Mac|iP(hone|[oa]d)/.test(navigator.platform) ? "Cmd" : "Ctrl") + mapping.slice(3);
 }
 
 /**

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -217,7 +217,7 @@ export function escapeHTML(
  * @param label The type to toggle to
  * @param mapping? Corresponding command mapping (keyboard shortcut)
  */
-export function getShortcut(mapping?: string): string {
+export function getShortcut(mapping: string): string {
     if (mapping.indexOf("Mod-") !== 0) {
         return mapping;
     }

--- a/test/shared/utils.test.ts
+++ b/test/shared/utils.test.ts
@@ -173,6 +173,7 @@ describe("utils", () => {
 
             const shortcut = getShortcut("Mod-z");
             expect(shortcut).toBe("Ctrl-z");
+            expect(navigator.platform).toBe("Win32");
 
             // Reset the platform
             setNavigatorProperty("platform", "");

--- a/test/shared/utils.test.ts
+++ b/test/shared/utils.test.ts
@@ -6,6 +6,17 @@ import {
     getShortcut,
 } from "../../src/shared/utils";
 
+const setNavigatorProperty = (
+    property: string,
+    value: string,
+    configurable = true
+): void => {
+    Object.defineProperty(navigator, property, {
+        value,
+        configurable,
+    });
+};
+
 describe("utils", () => {
     describe("deepmerge", () => {
         it("should merge two objects", () => {
@@ -145,13 +156,30 @@ describe("utils", () => {
     });
 
     describe("getShortcut", () => {
-        it("should replace `Mod` with appropriate modifier key for current platform", () => {
+        it("should replace `Mod` with `Cmd` when platform contains `Mac`", () => {
+            // Set the platform to macOS
+            setNavigatorProperty("platform", "MacIntel");
+
+            const shortcut = getShortcut("Mod-z");
+            expect(shortcut).toBe("Cmd-z");
+            expect(navigator.platform).toBe("MacIntel");
+
+            // Reset the platform
+            setNavigatorProperty("platform", "");
+        });
+        it("should replace `Mod` with `Ctrl` when platform is not an Apple platform", () => {
+            // Set the platform to Windows
+            setNavigatorProperty("platform", "Win32");
+
             const shortcut = getShortcut("Mod-z");
             expect(shortcut).toBe("Ctrl-z");
+
+            // Reset the platform
+            setNavigatorProperty("platform", "");
         });
         it("should return unmodified string when `Mod` isn't passed", () => {
             const shortcut = getShortcut("Cmd-y");
-            expect(shortcut).toBe("Cmd-y");
+            expect(shortcut).toBe("Cmd-y" + navigator.platform);
         });
     });
 });

--- a/test/shared/utils.test.ts
+++ b/test/shared/utils.test.ts
@@ -3,6 +3,7 @@ import {
     deepMerge,
     escapeHTML,
     stackOverflowValidateLink,
+    getShortcut,
 } from "../../src/shared/utils";
 
 describe("utils", () => {
@@ -141,5 +142,16 @@ describe("utils", () => {
                 expect(keys[0]).not.toBe(keys[1]);
             }
         );
+    });
+
+    describe("getShortcut", () => {
+        it("should replace `Mod` with appropriate modifier key for current platform", () => {
+            const shortcut = getShortcut("Mod-z");
+            expect(shortcut).toBe("Ctrl-z");
+        });
+        it("should return unmodified string when `Mod` isn't passed", () => {
+            const shortcut = getShortcut("Cmd-y");
+            expect(shortcut).toBe("Cmd-y");
+        });
     });
 });


### PR DESCRIPTION
resolves #46

---

After _far_ too much time trying to figure out how to get keyboard shortcuts from [src/rich-text/key-bindings.ts](https://github.com/StackExchange/Stacks-Editor/blob/main/src/rich-text/key-bindings.ts) to correspond to [src/rich-text/commands/index.ts](https://github.com/StackExchange/Stacks-Editor/blob/main/src/rich-text/commands/index.ts), I realized it would probably be fragile at best and impossible at worst.

I think the best way to add these shortcut labels is to just include them on the labels without pulling from anywhere.

### Note

This PR unifies tooltip text mostly by removing prefixed `Insert` (as in `Insert Code Block`).

### TODO

- [x] Add shortcuts to commonmark editor button tooltips
- [x] Figure out shortcut casing
- [x] We can probably remove all the `ctrl + b` and just display as provided (like `Ctrl-B`)