### PR TITLE
chore: specify highlight.js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-jest": "^26.1.5",
                 "eslint-plugin-no-unsanitized": "^4.0.1",
-                "highlight.js": "*",
+                "highlight.js": "^11.5.1",
                 "html-loader": "^3.1.0",
                 "html-webpack-plugin": "^5.5.0",
                 "husky": "^8.0.1",
@@ -5837,9 +5837,9 @@
             "dev": true
         },
         "node_modules/highlight.js": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
-            "integrity": "sha512-EqYpWyTF2s8nMfttfBA2yLKPNoZCO33pLS4MnbXQ4hECf1TKujCt1Kq7QAdrio7roL4+CqsfjqwYj4tYgq0pJQ==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
+            "integrity": "sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==",
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -16862,9 +16862,9 @@
             "dev": true
         },
         "highlight.js": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
-            "integrity": "sha512-EqYpWyTF2s8nMfttfBA2yLKPNoZCO33pLS4MnbXQ4hECf1TKujCt1Kq7QAdrio7roL4+CqsfjqwYj4tYgq0pJQ=="
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
+            "integrity": "sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q=="
         },
         "hosted-git-info": {
             "version": "2.8.9",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-jest": "^26.1.5",
         "eslint-plugin-no-unsanitized": "^4.0.1",
-        "highlight.js": "*",
+        "highlight.js": "^11.5.1",
         "html-loader": "^3.1.0",
         "html-webpack-plugin": "^5.5.0",
         "husky": "^8.0.1",


### PR DESCRIPTION
## Describe your changes

This PR updates sets the version to `^11.5.1.`

We were locked at `11.0.1` because it was specified in `package-lock.json` and we using `*` as the version in `package.json`.

## Additional context

This should address some of this issues in https://github.com/StackExchange/Stacks-Editor/issues/21.

### Fixed with this PR

- [Triple asterisks don't terminate](https://github.com/StackExchange/Stacks-Editor/issues/21#issuecomment-831248428)

### Not fixed with this PR

- [Non-terminating italics](https://meta.stackexchange.com/a/360038/395497)
- [Escaped asterisks](https://meta.stackexchange.com/a/360050/395497)
- [Multi-line asterisks](https://meta.stackexchange.com/a/360153/395497)