### PR TITLE
fix(markdown-mode): prevent block change from stripping numbers

### DIFF
--- a/src/commonmark/commands.ts
+++ b/src/commonmark/commands.ts
@@ -196,7 +196,15 @@ function setBlockType(
 function matchLeadingBlockCharacters(text: string) {
     // TODO this might be too aggressive... remove based on a whitelist instead?
     // TODO HACK assumes all block types are non-letter characters followed by a single space
-    return /^[^a-zA-Z]+\s{1}(?=[a-zA-Z_*[!]|$)/.exec(text)?.[0] || "";
+    // Match ordered lists prefixes
+    let match = /^(\d+)\.\s/.exec(text)?.[0];
+
+    // If text is not an ordered list block, check for other block types
+    if (!match) {
+        match = /^[^a-zA-Z0-9]+\s{1}(?=[a-zA-Z0-9_*[!]|$)+/.exec(text)?.[0];
+    }
+
+    return match || "";
 }
 
 /**


### PR DESCRIPTION
fixes #69

**Describe your changes**

This PR prevents markdown mode commands from stripping numbers from the beginning of strings when changing the block type. It achieves this by checking first for ordered list block types then for any non-alpha*numeric* leading characters.

**PR Checklist**

- [ ] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [ ] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: desktop
- OS: Mac OS
- Browser: Firefox 101.0

**Additional context**

The regexes in `matchLeadingBlockCharacters` could for sure use some work. This PR targets the specific issue mentioned in #69 but could be refactored to check leading characters per the markdown spec.
