### PR TITLE
fix(commonmark-editor): prevent placeholder clipping

### DIFF
--- a/src/styles/custom-components.less
+++ b/src/styles/custom-components.less
@@ -213,7 +213,7 @@
         position: relative;
 
         // ensures markdown placeholder wraps expectedly
-        &.markdown {
+        &.s-code-block.markdown {
             overflow: visible;
         }
 

--- a/src/styles/custom-components.less
+++ b/src/styles/custom-components.less
@@ -212,6 +212,11 @@
     & [data-placeholder] {
         position: relative;
 
+        // ensures markdown placeholder wraps expectedly
+        &.markdown {
+            overflow: visible;
+        }
+
         &::before {
             color: var(--fc-light);
             position: absolute;


### PR DESCRIPTION
fixes #143 

This is a simple one. Requesting a review just to see if there's any opinions about approach to overflow here (like, we could use `inherit` or `unset` if we wanted to be a little less prescriptive).

Examples with very long placeholder text (`This is placeholder text, so start typing…` repeated like 43 times)
### Before

<img width="663" alt="image" src="https://user-images.githubusercontent.com/647177/174887048-a322765c-c83f-4277-a366-df0f3428ab24.png">

### After
<img width="655" alt="image" src="https://user-images.githubusercontent.com/647177/174886956-8853f1c1-b1c8-48f2-89ed-eea12ff80d9c.png">
