### PR TITLE
fix(commonmark-editor) ensure newline after html_block

### DIFF
--- a/src/shared/markdown-serializer.ts
+++ b/src/shared/markdown-serializer.ts
@@ -317,6 +317,8 @@ const customMarkdownSerializerNodes: MarkdownSerializerNodes = {
     // TODO
     html_block(state, node) {
         state.write(node.attrs.content);
+        state.ensureNewLine();
+        state.write("\n");
     },
 
     // TODO

--- a/test/shared/markdown-serializer.test.ts
+++ b/test/shared/markdown-serializer.test.ts
@@ -126,12 +126,18 @@ describe("markdown-serializer", () => {
         `- li1\n- li2\n- li3`,
         `+ li1\n+ li2\n+ li3`,
         `* li1\n* li2\n* li3`,
-        [`<ul><li>li1</li><li>li2</li></ul>`, `<ul><li>li1</li><li>li2</li></ul>\n\n`],
+        [
+            `<ul><li>li1</li><li>li2</li></ul>`,
+            `<ul><li>li1</li><li>li2</li></ul>\n\n`,
+        ],
         // ordered item numbers will auto-increment
         [`1. li1\n1. li2\n1. li3`, `1. li1\n2. li2\n3. li3`],
         `1. li1\n2. li2\n3. li3`,
         `1) li1\n2) li2\n3) li3`,
-        [`<ol><li>li1</li><li>li2</li></ol>`, `<ol><li>li1</li><li>li2</li></ol>\n\n`],
+        [
+            `<ol><li>li1</li><li>li2</li></ol>`,
+            `<ol><li>li1</li><li>li2</li></ol>\n\n`,
+        ],
         //loose lists
         `- li1\n\n- li2\n\n- li3`,
         `1. li1\n\n2. li2\n\n3. li3`,

--- a/test/shared/markdown-serializer.test.ts
+++ b/test/shared/markdown-serializer.test.ts
@@ -103,7 +103,7 @@ describe("markdown-serializer", () => {
         `<p>html paragraph</p>`,
         "```js\ntest\n```",
         "~~~\ntest\n~~~",
-        `<pre><code>test</code></pre>`,
+        [`<pre><code>test</code></pre>`, `<pre><code>test</code></pre>\n\n`],
         `# ATX heading`,
         // TODO Setext headings don't remember the number of "underline" characters
         [`Setext heading\n===`, `Setext heading\n=`],
@@ -126,12 +126,12 @@ describe("markdown-serializer", () => {
         `- li1\n- li2\n- li3`,
         `+ li1\n+ li2\n+ li3`,
         `* li1\n* li2\n* li3`,
-        `<ul><li>li1</li><li>li2</li></ul>`,
+        [`<ul><li>li1</li><li>li2</li></ul>`, `<ul><li>li1</li><li>li2</li></ul>\n\n`],
         // ordered item numbers will auto-increment
         [`1. li1\n1. li2\n1. li3`, `1. li1\n2. li2\n3. li3`],
         `1. li1\n2. li2\n3. li3`,
         `1) li1\n2) li2\n3) li3`,
-        `<ol><li>li1</li><li>li2</li></ol>`,
+        [`<ol><li>li1</li><li>li2</li></ol>`, `<ol><li>li1</li><li>li2</li></ol>\n\n`],
         //loose lists
         `- li1\n\n- li2\n\n- li3`,
         `1. li1\n\n2. li2\n\n3. li3`,


### PR DESCRIPTION
Addresses part of [152](https://github.com/StackExchange/Stacks-Editor/issues/152). 

**Describe your changes**

This simply ensures two newlines happen at the end of `html_block` nodes. Having other Markdown code on the line immediately after an `html_block` can cause rendering issues when round-tripping between MD and RT editors.

**PR Checklist**

- [X] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [ ] All new/changed functions have `/** ... */` docs
- [X] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: Desktop
- OS: Windows 10
- Browser: Chrome
- Version: 103