### PR TITLE
fix(commonmark-editor) Update preview timing and styles

### DIFF
--- a/src/commonmark/plugins/preview.ts
+++ b/src/commonmark/plugins/preview.ts
@@ -11,7 +11,7 @@ import type { CommonmarkOptions } from "../editor";
  * The amount of time to delay rendering since the last render;
  * Setting to a high value will result in less frequent renders as users type
  */
-const DEFAULT_RENDER_DELAY_MS = 1000;
+const DEFAULT_RENDER_DELAY_MS = 100;
 
 class PreviewView implements PluginView {
     dom: HTMLDivElement;

--- a/src/commonmark/plugins/preview.ts
+++ b/src/commonmark/plugins/preview.ts
@@ -31,9 +31,7 @@ class PreviewView implements PluginView {
             previewOptions?.renderer ||
             createDefaultMarkdownItInstance({
                 ...parserFeatures,
-                // TODO until we handle proper html sanitizing in the renderer,
-                // we need to disable html entirely...
-                html: false,
+                html: true,
             });
 
         this.renderDelayMs =

--- a/src/shared/markdown-parser.ts
+++ b/src/shared/markdown-parser.ts
@@ -256,7 +256,12 @@ export function createDefaultMarkdownItInstance(
         linkify: true, // automatically link plain URLs
     });
 
-    if (!features.tables) {
+    if (features.tables) {
+        defaultMarkdownItInstance.enable("table");
+        defaultMarkdownItInstance.renderer.rules.table_open = () => '<div class="s-table-container"><table class="s-table">';
+        defaultMarkdownItInstance.renderer.rules.table_close = () => '</table></div>';
+    }
+    else {
         defaultMarkdownItInstance.disable("table");
     }
 


### PR DESCRIPTION
- Shorter delay on preview rendering (100 ms instead of 1 second), to make the experience more responsive, closer to how it is on the site today
- Turn on html for renderer. We use markdown-it on the main site for the current preview renderer, and html is enabled there without issue. When it is on, it is going through our sanitize already. So unless anything else missing, no reason not to have it on
- Customize open and close table in markdown-it the [same way that we do it](https://github.com/StackEng/StackOverflow/blob/baba2a3a08bd75da2616315662d7198f0c50b856/StackOverflow/_Scripts/LegacyJS/markdown/markdown-it-loader.js#L10-L10) on the current preview renderer.