### PR TITLE
fix(commonmark) nested sub tags getting lost when round-tripping

### DIFF
--- a/src/rich-text/schema.ts
+++ b/src/rich-text/schema.ts
@@ -517,8 +517,8 @@ const marks: {
         excludes: "",
         attrs: {
             nesting: {
-                default: null
-            }
+                default: null,
+            },
         },
         parseDOM: [{ tag: "sup", getAttrs: nesting("sup") }],
     },
@@ -528,11 +528,11 @@ const marks: {
         excludes: "",
         attrs: {
             nesting: {
-                default: null
-            }
+                default: null,
+            },
         },
         parseDOM: [{ tag: "sub", getAttrs: nesting("sub") }],
-    }
+    },
 };
 
 // for *every* mark, add in support for the `markup` attribute
@@ -596,17 +596,18 @@ function genHtmlInlineMarkSpec(
     };
 }
 
-function nesting(...args : string[]) {
-    const fn = (node : any) => {
-      let el = (node as HTMLElement).parentElement
-      let nesting = 0
-      while(el !== null) {
-        if (args.includes(el.tagName)) {
-            nesting++
+// TODO necessary? Might be required for pasting from other sources
+function nesting(...args: string[]) {
+    const fn = (node: HTMLElement) => {
+        let el = node.parentElement;
+        let nesting = 0;
+        while (el !== null) {
+            if (args.includes(el.tagName)) {
+                nesting++;
+            }
+            el = el.parentElement;
         }
-        el = el.parentElement
-      }
-      return {nesting: nesting}
-    }
-    return fn
-  }
+        return { nesting: nesting };
+    };
+    return fn;
+}

--- a/src/rich-text/schema.ts
+++ b/src/rich-text/schema.ts
@@ -512,9 +512,15 @@ const marks: {
 
     kbd: genHtmlInlineMarkSpec({ exitable: true, inclusive: true }, "kbd"),
 
-    sup: genHtmlInlineMarkSpec({}, "sup"),
+    sup: {
+        ...genHtmlInlineMarkSpec({}, "sup"),
+        excludes: "",
+    },
 
-    sub: genHtmlInlineMarkSpec({}, "sub"),
+    sub: {
+        ...genHtmlInlineMarkSpec({}, "sub"),
+        excludes: "",
+    }
 };
 
 // for *every* mark, add in support for the `markup` attribute

--- a/src/rich-text/schema.ts
+++ b/src/rich-text/schema.ts
@@ -515,11 +515,23 @@ const marks: {
     sup: {
         ...genHtmlInlineMarkSpec({}, "sup"),
         excludes: "",
+        attrs: {
+            nesting: {
+                default: null
+            }
+        },
+        parseDOM: [{ tag: "sup", getAttrs: nesting("sup") }],
     },
 
     sub: {
         ...genHtmlInlineMarkSpec({}, "sub"),
         excludes: "",
+        attrs: {
+            nesting: {
+                default: null
+            }
+        },
+        parseDOM: [{ tag: "sub", getAttrs: nesting("sub") }],
     }
 };
 
@@ -583,3 +595,18 @@ function genHtmlInlineMarkSpec(
         parseDOM: tags.map((tag) => ({ tag: tag })),
     };
 }
+
+function nesting(...args : string[]) {
+    const fn = (node : any) => {
+      let el = (node as HTMLElement).parentElement
+      let nesting = 0
+      while(el !== null) {
+        if (args.includes(el.tagName)) {
+            nesting++
+        }
+        el = el.parentElement
+      }
+      return {nesting: nesting}
+    }
+    return fn
+  }

--- a/src/shared/markdown-it/html.ts
+++ b/src/shared/markdown-it/html.ts
@@ -347,9 +347,10 @@ function sanitizeInlineHtmlTokens(tokens: Token[]): Token[] {
         for (let j = i + 1, len2 = tokens.length; j < len2; j++) {
             const closeToken = tokens[j];
 
-            // not inline or already paired, skip
+            // not inline, not a closetoken, or already paired, skip
             if (
                 !closeToken ||
+                !closeToken.type.includes("_close") || // cannot be a close token if…not a close token
                 !closeToken.attrGet("inline_html") ||
                 closeToken.attrGet("paired")
             ) {

--- a/src/shared/markdown-it/html.ts
+++ b/src/shared/markdown-it/html.ts
@@ -354,6 +354,11 @@ function sanitizeInlineHtmlTokens(tokens: Token[]): Token[] {
             openToken.type = "html_inline";
             continue;
         } else if (openToken.type.includes("_close")) {
+            openToken.attrSet(
+                "nesting",
+                nestingLevel[tagName]?.toString() || "0"
+            );
+
             // found a paired close tag, decrement the nesting level for that type
             decreaseNestingLevel(tagName);
         }

--- a/src/shared/markdown-parser.ts
+++ b/src/shared/markdown-parser.ts
@@ -19,7 +19,12 @@ const customMarkdownParserTokens: MarkdownParser["tokens"] = {
     pre: { block: "pre" },
     kbd: { mark: "kbd" },
     sup: { mark: "sup" },
-    sub: { mark: "sub" },
+    sub: {
+        mark: "sub",
+        getAttrs: (token: Token) => ({
+            nesting: token.attrGet("nesting"),
+        }),
+    },
 
     html_inline: {
         node: "html_inline",

--- a/test/rich-text/editor.test.ts
+++ b/test/rich-text/editor.test.ts
@@ -246,8 +246,9 @@ _world_.
             const expectedHtml = `<p><em><strong><del>wtf?</del></strong></em></p>`;
             expect(editorDom(richEditorView)).toEqual(normalize(expectedHtml));
         });
-
-        it("should allow nested <sub><sub>text</sub></sub> strings", () => {
+        
+        // skip pending resolution of upstream issues with prosemirror that are preventing this from working properly
+        it.skip("should allow nested <sub><sub>text</sub></sub> strings", () => {
             const markdown = "<sub><sub>text</sub></sub>";
             const richEditorView = richView(markdown);
             const expectedHtml = "<p><sub><sub>text</sub></sub></p>"; // should not be changed

--- a/test/rich-text/editor.test.ts
+++ b/test/rich-text/editor.test.ts
@@ -248,7 +248,7 @@ _world_.
         });
         
         // skip pending resolution of upstream issues with prosemirror that are preventing this from working properly
-        it.skip("should allow nested <sub><sub>text</sub></sub> strings", () => {
+        it("should allow nested <sub><sub>text</sub></sub> strings", () => {
             const markdown = "<sub><sub>text</sub></sub>";
             const richEditorView = richView(markdown);
             const expectedHtml = "<p><sub><sub>text</sub></sub></p>"; // should not be changed

--- a/test/rich-text/editor.test.ts
+++ b/test/rich-text/editor.test.ts
@@ -247,6 +247,13 @@ _world_.
             expect(editorDom(richEditorView)).toEqual(normalize(expectedHtml));
         });
 
+        it("should allow nested <sub><sub>text</sub></sub> strings", () => {
+            const markdown = "<sub><sub>text</sub></sub>";
+            const richEditorView = richView(markdown);
+            const expectedHtml = "<p><sub><sub>text</sub></sub></p>"; // should not be changed
+            expect(editorDom(richEditorView)).toEqual(expectedHtml);
+        });
+
         it("should render markdown within inline HTML", () => {
             const markdown = "<em>**text**</em>";
             const richEditorView = richView(markdown);

--- a/test/rich-text/editor.test.ts
+++ b/test/rich-text/editor.test.ts
@@ -246,12 +246,12 @@ _world_.
             const expectedHtml = `<p><em><strong><del>wtf?</del></strong></em></p>`;
             expect(editorDom(richEditorView)).toEqual(normalize(expectedHtml));
         });
-        
+
         // skip pending resolution of upstream issues with prosemirror that are preventing this from working properly
         it("should allow nested <sub><sub>text</sub></sub> strings", () => {
-            const markdown = "<sub><sub>text</sub></sub>";
+            const markdown = "<sub>1<sub>text</sub>2</sub>";
             const richEditorView = richView(markdown);
-            const expectedHtml = "<p><sub><sub>text</sub></sub></p>"; // should not be changed
+            const expectedHtml = "<p><sub>1<sub>text</sub>2</sub></p>"; // should not be changed
             expect(editorDom(richEditorView)).toEqual(expectedHtml);
         });
 

--- a/test/shared/markdown-it/html.test.ts
+++ b/test/shared/markdown-it/html.test.ts
@@ -189,6 +189,22 @@ describe("html markdown-it plugin", () => {
             expect(tokens).toHaveLength(1);
             expect(tokens[0].type).toBe("html_block");
         });
+
+        it("should handle nested inline tags of the same type", () => {
+            const markdown = `<sub>1<sub>2</sub>3</sub>`;
+            const tokens = instance.parse(markdown, {});
+            expect(tokens).toHaveLength(3);
+            const inline = tokens[1];
+            expect(inline.type).toBe("inline");
+            expect(inline.children).toHaveLength(7);
+            expect(inline.children[0].type).toBe("sub_open");
+            expect(inline.children[1].type).toBe("text");
+            expect(inline.children[2].type).toBe("sub_open");
+            expect(inline.children[3].type).toBe("text");
+            expect(inline.children[4].type).toBe("sub_close");
+            expect(inline.children[5].type).toBe("text");
+            expect(inline.children[6].type).toBe("sub_close");
+        });
     });
 
     describe("html_block", () => {

--- a/test/shared/markdown-parser.test.ts
+++ b/test/shared/markdown-parser.test.ts
@@ -93,6 +93,39 @@ describe("SOMarkdownParser", () => {
 
         //const doc = markdownParser.parse("<ul><li><em>test</em></li></ul>");
         it.todo("should support block html with deep nesting");
+
+        it("should support valid nested inline html", () => {
+            const doc = markdownParser.parse("<sub>1<sub>2</sub>3</sub>");
+
+            expect(doc).toMatchNodeTree({
+                content: [
+                    {
+                        "type.name": "paragraph",
+                        "content": [
+                            {
+                                "isText": true,
+                                "text": "1",
+                                "marks.length": 1,
+                                "marks.0.type.name": "sub",
+                            },
+                            {
+                                "isText": true,
+                                "text": "2",
+                                "marks.length": 2,
+                                "marks.0.type.name": "sub",
+                                "marks.1.type.name": "sub",
+                            },
+                            {
+                                "isText": true,
+                                "text": "3",
+                                "marks.length": 1,
+                                "marks.0.type.name": "sub",
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
     });
 
     // NOTE: detailed / edge case testing is done in the plugin specific tests,


### PR DESCRIPTION
Closes #32 

Thus far:

- Added failing test
- Fixed issue with `sanitizeInlineHtmlTokens` to ensure that it doesnt consider a second open tag to be the closing tag for the first matching open tag

@b-kelly from what I was able to determine, this is still failing however, since when it is converted into the prosemirror `doc`, it becomes a `node` with the text as the content and `sub` as the attribute. And seems that it just cant figure out two open tags of the same type.

Looking for advice on where to go from here - assume that I need to add to the prosemirror the ability to recognize this. Does this mean a schema change, to allow a sub to have a child sub? Need to get it recognized both into PM and out of it back to markdown. If there is prior PRs that do this sort of thing that I can study, would appreciate it. Can talk about this in our scheduled time tomorrow.