### PR TITLE
bug (dont hide image upload instructions in editor on mobile

### DIFF
--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -159,7 +159,7 @@ export class ImageUploader extends PluginInterfaceView<
             <div class="d-flex ai-center p12">
                 <button class="s-btn s-btn__primary ws-nowrap mr8 js-add-image" type="button" disabled>Add image</button>
                 <button class="s-btn ws-nowrap js-cancel-button" type="button">Cancel</button>
-                <div class="ml64 d-flex fd-column fs-caption fc-black-300 s-anchors s-anchors__muted">
+                <div class="ml64 sm:ml0 d-flex fd-column fs-caption fc-black-300 s-anchors s-anchors__muted">
                     <div class="js-branding-html"></div>
                     <div class="js-content-policy-html"></div>
                 </div>


### PR DESCRIPTION
Closes #202 

**Describe your changes**

On small width, remove left margin before upload instructions to ensure that it is shown.

Before:
![screenshot](https://i.stack.imgur.com/434pe.jpg)

After:
![image](https://user-images.githubusercontent.com/1366941/179842078-162090dd-6d14-4159-8397-355d76f6a36e.png)

**Environment(s) tested**

Windows 10 Chrome 103, dev tools
