### PR TITLE
enhancement(editor) All shortcuts are shown in popovers with capital letters

### DIFF
--- a/src/commonmark/commands.ts
+++ b/src/commonmark/commands.ts
@@ -728,7 +728,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 dom: makeMenuButton(
                     "Header",
                     _t("commands.heading.dropdown", {
-                        shortcut: getShortcut("Mod-h"),
+                        shortcut: getShortcut("Mod-H"),
                     }),
                     "heading-btn"
                 ),
@@ -738,7 +738,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 command: boldCommand,
                 dom: makeMenuButton(
                     "Bold",
-                    _t("commands.bold", { shortcut: getShortcut("Mod-b") }),
+                    _t("commands.bold", { shortcut: getShortcut("Mod-B") }),
                     "bold-btn"
                 ),
             },
@@ -747,7 +747,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 command: emphasisCommand,
                 dom: makeMenuButton(
                     "Italic",
-                    _t("commands.emphasis", { shortcut: getShortcut("Mod-i") }),
+                    _t("commands.emphasis", { shortcut: getShortcut("Mod-I") }),
                     "italic-btn"
                 ),
             },
@@ -757,7 +757,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 dom: makeMenuButton(
                     "Code",
                     _t("commands.inline_code", {
-                        shortcut: getShortcut("Mod-k"),
+                        shortcut: getShortcut("Mod-K"),
                     }),
                     "code-btn"
                 ),
@@ -785,7 +785,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 command: insertLinkCommand,
                 dom: makeMenuButton(
                     "Link",
-                    _t("commands.link", { shortcut: getShortcut("Mod-l") }),
+                    _t("commands.link", { shortcut: getShortcut("Mod-L") }),
                     "insert-link-btn"
                 ),
             },
@@ -795,7 +795,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 dom: makeMenuButton(
                     "Quote",
                     _t("commands.blockquote", {
-                        shortcut: getShortcut("Ctrl-q"),
+                        shortcut: getShortcut("Ctrl-Q"),
                     }),
                     "blockquote-btn"
                 ),
@@ -806,7 +806,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 dom: makeMenuButton(
                     "Codeblock",
                     _t("commands.code_block", {
-                        shortcut: getShortcut("Mod-m"),
+                        shortcut: getShortcut("Mod-M"),
                     }),
                     "code-block-btn"
                 ),
@@ -818,7 +818,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                     dom: makeMenuButton(
                         "Image",
                         _t("commands.image", {
-                            shortcut: getShortcut("Mod-g"),
+                            shortcut: getShortcut("Mod-G"),
                         }),
                         "insert-image-btn"
                     ),
@@ -832,7 +832,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                     dom: makeMenuButton(
                         "Table",
                         _t("commands.table_insert", {
-                            shortcut: getShortcut("Mod-e"),
+                            shortcut: getShortcut("Mod-E"),
                         }),
                         "insert-table-btn"
                     ),
@@ -851,7 +851,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 dom: makeMenuButton(
                     "OrderedList",
                     _t("commands.ordered_list", {
-                        shortcut: getShortcut("Mod-o"),
+                        shortcut: getShortcut("Mod-O"),
                     }),
                     "numbered-list-btn"
                 ),
@@ -862,7 +862,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 dom: makeMenuButton(
                     "UnorderedList",
                     _t("commands.unordered_list", {
-                        shortcut: getShortcut("Mod-u"),
+                        shortcut: getShortcut("Mod-U"),
                     }),
                     "bullet-list-btn"
                 ),
@@ -873,7 +873,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 dom: makeMenuButton(
                     "HorizontalRule",
                     _t("commands.horizontal_rule", {
-                        shortcut: getShortcut("Mod-r"),
+                        shortcut: getShortcut("Mod-R"),
                     }),
                     "horizontal-rule-btn"
                 ),
@@ -889,7 +889,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 command: undo,
                 dom: makeMenuButton(
                     "Undo",
-                    _t("commands.undo", { shortcut: getShortcut("Mod-z") }),
+                    _t("commands.undo", { shortcut: getShortcut("Mod-Z") }),
                     "undo-btn",
                     ["sm:d-inline-block"]
                 ),
@@ -900,7 +900,7 @@ export const createMenuEntries = (options: CommonViewOptions): MenuBlock[] => [
                 command: redo,
                 dom: makeMenuButton(
                     "Refresh",
-                    _t("commands.redo", { shortcut: getShortcut("Mod-y") }),
+                    _t("commands.redo", { shortcut: getShortcut("Mod-Y") }),
                     "redo-btn",
                     ["sm:d-inline-block"]
                 ),

--- a/src/rich-text/commands/index.ts
+++ b/src/rich-text/commands/index.ts
@@ -394,7 +394,7 @@ const tableDropdown = () =>
 const headingDropdown = (schema: Schema) =>
     makeMenuDropdown(
         "Header",
-        _t("commands.heading.dropdown", { shortcut: getShortcut("Mod-h") }),
+        _t("commands.heading.dropdown", { shortcut: getShortcut("Mod-H") }),
         "heading-dropdown",
         () => true,
         nodeTypeActive(schema.nodes.heading),
@@ -442,7 +442,7 @@ export const createMenuEntries = (
                 command: toggleMark(schema.marks.strong),
                 dom: makeMenuButton(
                     "Bold",
-                    _t("commands.bold", { shortcut: getShortcut("Mod-b") }),
+                    _t("commands.bold", { shortcut: getShortcut("Mod-B") }),
                     "bold-btn"
                 ),
                 active: markActive(schema.marks.strong),
@@ -452,7 +452,7 @@ export const createMenuEntries = (
                 command: toggleMark(schema.marks.em),
                 dom: makeMenuButton(
                     "Italic",
-                    _t("commands.emphasis", { shortcut: getShortcut("Mod-i") }),
+                    _t("commands.emphasis", { shortcut: getShortcut("Mod-I") }),
                     "italic-btn"
                 ),
                 active: markActive(schema.marks.em),
@@ -463,7 +463,7 @@ export const createMenuEntries = (
                 dom: makeMenuButton(
                     "Code",
                     _t("commands.inline_code", {
-                        shortcut: getShortcut("Mod-k"),
+                        shortcut: getShortcut("Mod-K"),
                     }),
                     "code-btn"
                 ),
@@ -493,7 +493,7 @@ export const createMenuEntries = (
                 command: insertLinkCommand,
                 dom: makeMenuButton(
                     "Link",
-                    _t("commands.link", { shortcut: getShortcut("Mod-l") }),
+                    _t("commands.link", { shortcut: getShortcut("Mod-L") }),
                     "insert-link-btn"
                 ),
             },
@@ -503,7 +503,7 @@ export const createMenuEntries = (
                 dom: makeMenuButton(
                     "Quote",
                     _t("commands.blockquote", {
-                        shortcut: getShortcut("Mod-q"),
+                        shortcut: getShortcut("Mod-Q"),
                     }),
                     "blockquote-btn"
                 ),
@@ -515,7 +515,7 @@ export const createMenuEntries = (
                 dom: makeMenuButton(
                     "Codeblock",
                     _t("commands.code_block", {
-                        shortcut: getShortcut("Mod-m"),
+                        shortcut: getShortcut("Mod-M"),
                     }),
                     "code-block-btn"
                 ),
@@ -528,7 +528,7 @@ export const createMenuEntries = (
                     dom: makeMenuButton(
                         "Image",
                         _t("commands.image", {
-                            shortcut: getShortcut("Mod-g"),
+                            shortcut: getShortcut("Mod-G"),
                         }),
                         "insert-image-btn"
                     ),
@@ -542,7 +542,7 @@ export const createMenuEntries = (
                     dom: makeMenuButton(
                         "Table",
                         _t("commands.table_insert", {
-                            shortcut: getShortcut("Mod-e"),
+                            shortcut: getShortcut("Mod-E"),
                         }),
                         "insert-table-btn"
                     ),
@@ -564,7 +564,7 @@ export const createMenuEntries = (
                 dom: makeMenuButton(
                     "OrderedList",
                     _t("commands.ordered_list", {
-                        shortcut: getShortcut("Mod-o"),
+                        shortcut: getShortcut("Mod-O"),
                     }),
                     "numbered-list-btn"
                 ),
@@ -576,7 +576,7 @@ export const createMenuEntries = (
                 dom: makeMenuButton(
                     "UnorderedList",
                     _t("commands.unordered_list", {
-                        shortcut: getShortcut("Mod-u"),
+                        shortcut: getShortcut("Mod-U"),
                     }),
                     "bullet-list-btn"
                 ),
@@ -588,7 +588,7 @@ export const createMenuEntries = (
                 dom: makeMenuButton(
                     "HorizontalRule",
                     _t("commands.horizontal_rule", {
-                        shortcut: getShortcut("Mod-r"),
+                        shortcut: getShortcut("Mod-R"),
                     }),
                     "horizontal-rule-btn"
                 ),
@@ -604,7 +604,7 @@ export const createMenuEntries = (
                 command: undo,
                 dom: makeMenuButton(
                     "Undo",
-                    _t("commands.undo", { shortcut: getShortcut("Mod-z") }),
+                    _t("commands.undo", { shortcut: getShortcut("Mod-Z") }),
                     "undo-btn"
                 ),
             },
@@ -613,7 +613,7 @@ export const createMenuEntries = (
                 command: redo,
                 dom: makeMenuButton(
                     "Refresh",
-                    _t("commands.redo", { shortcut: getShortcut("Mod-y") }),
+                    _t("commands.redo", { shortcut: getShortcut("Mod-Y") }),
                     "redo-btn"
                 ),
             },

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -236,7 +236,7 @@ export function getShortcut(mapping: string): string {
 
     return (
         (/Mac|iP(hone|[oa]d)/.test(navigator.platform) ? "Cmd" : "Ctrl") +
-        mapping.slice(3)
+        mapping.slice(3).toUpperCase()
     );
 }
 


### PR DESCRIPTION
Closes #166

Change the shortcut keys to display with capital letters. No change to actual functionality.

**Environment(s) tested**
Windows 10 Chrome 103