### PR TITLE
fix(preview-plugin): Reinitialize Markdownit renderer with passed-in options

### DIFF
--- a/src/commonmark/plugins/preview.ts
+++ b/src/commonmark/plugins/preview.ts
@@ -42,9 +42,11 @@ class PreviewView implements PluginView {
         this.dom = document.createElement("div");
         this.dom.classList.add("s-prose", "py16", "js-md-preview");
         // TODO pass down the ExternalPluginProvider as well
-        this.renderer =
-            previewOptions?.renderer ||
-            createDefaultMarkdownItInstance({
+        this.renderer = previewOptions?.renderer 
+            // if renderer is passed in, need to reinitialize the renderer to ensure that prototype functions 
+            // that were excluded from deepmerge are included in the renderer being used here
+            ? new MarkdownIt(previewOptions.renderer.options)
+            : createDefaultMarkdownItInstance({
                 ...parserFeatures,
                 // TODO until we handle proper html sanitizing in the renderer,
                 // we need to disable html entirely...


### PR DESCRIPTION
Addresses issue holding up integration of editor preview in main core code.

Issue is that while the `DeepMerge` call that is made at the [top of the main constructor](https://github.com/StackExchange/Stacks-Editor/blob/c8714dfa7912a5c05e45fcb8da638644a07ed07a/src/stacks-editor/editor.ts#L71) for the editor copies all of the properties for the `MarkdownIt` instance being passed in at `options.commonmarkOptions.preview.renderer`, it does not copy in the prototype functions that are part of the object. So when the preview plugin tries to [use the renderer to render text](https://github.com/StackExchange/Stacks-Editor/blob/c8714dfa7912a5c05e45fcb8da638644a07ed07a/src/commonmark/plugins/preview.ts#L108), the `render` function is not present, and an error like this occurs.

![image](https://user-images.githubusercontent.com/1366941/189533495-e5d6142f-1589-4fd7-a3d9-cfe8c96bd90f.png)

**Describe your changes**

Changed the initialization of `this.renderer` in the main constructor so that in the case where a `MarkdownIt` renderer is passed in through `options`, it will use the passed-in options to initialize a new `MarkdownIt` object (which will have the relevant prototype functions attached).

Not quite sure how to test this through a unit test.

**PR Checklist**

- [ ] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Tested on chrome latest, Windows 10
- Fix is confirmed to work on local for importing an external `MarkdownIt` renderer and using it in Core code.