### PR TITLE
feat(bindings): support Cmd/Ctrl-Shift-Z hot key for history redo

### DIFF
--- a/src/commonmark/key-bindings.ts
+++ b/src/commonmark/key-bindings.ts
@@ -1,4 +1,3 @@
-import { keymap } from "prosemirror-keymap";
 import { redo, undo } from "prosemirror-history";
 import {
     boldCommand,
@@ -24,48 +23,42 @@ import {
 import type { CommonmarkParserFeatures } from "../shared/view";
 import { baseKeymap } from "prosemirror-commands";
 import type { Plugin } from "prosemirror-state";
-import { bindLetterKeymap } from "../shared/utils";
+import { caseNormalizeKeymap } from "../shared/prosemirror-plugins/case-normalize-keymap";
 
 export function allKeymaps(parserFeatures: CommonmarkParserFeatures): Plugin[] {
-    const commonmarkKeymap = keymap({
-        ...bindLetterKeymap("Mod-z", undo),
-        ...bindLetterKeymap("Mod-y", redo),
-        ...bindLetterKeymap("Mod-Shift-z", redo),
+    const commonmarkKeymap = caseNormalizeKeymap({
+        "Mod-z": undo,
+        "Mod-y": redo,
+        "Shift-Mod-z": redo,
         "Tab": indentCommand,
         "Shift-Tab": indentCommand,
-        ...bindLetterKeymap("Mod-b", boldCommand),
-        ...bindLetterKeymap("Mod-i", emphasisCommand),
-        ...bindLetterKeymap("Mod-l", insertCommonmarkLinkCommand),
-        ...bindLetterKeymap("Ctrl-q", blockquoteCommand),
-        ...bindLetterKeymap("Mod-k", inlineCodeCommand),
-        ...bindLetterKeymap("Mod-g", insertCommonmarkImageCommand),
-        ...bindLetterKeymap("Ctrl-g", insertCommonmarkImageCommand),
-        ...bindLetterKeymap("Mod-o", orderedListCommand),
-        ...bindLetterKeymap("Mod-u", unorderedListCommand),
-        ...bindLetterKeymap("Mod-h", headerCommand),
-        ...bindLetterKeymap("Mod-r", insertCommonmarkHorizontalRuleCommand),
-        ...bindLetterKeymap("Mod-m", insertCodeblockCommand),
-        ...bindLetterKeymap(
-            "Mod-[",
-            insertTagLinkCommand(parserFeatures.tagLinks.validate, false)
-        ),
-        ...bindLetterKeymap(
-            "Mod-]",
-            insertTagLinkCommand(parserFeatures.tagLinks.validate, true)
-        ),
-        ...bindLetterKeymap("Mod-/", spoilerCommand),
-        ...bindLetterKeymap("Mod-,", subCommand),
-        ...bindLetterKeymap("Mod-.", supCommand),
-        ...bindLetterKeymap("Mod-'", kbdCommand),
+        "Mod-b": boldCommand,
+        "Mod-i": emphasisCommand,
+        "Mod-l": insertCommonmarkLinkCommand,
+        "Ctrl-q": blockquoteCommand,
+        "Mod-k": inlineCodeCommand,
+        "Mod-g": insertCommonmarkImageCommand,
+        "Ctrl-g": insertCommonmarkImageCommand,
+        "Mod-o": orderedListCommand,
+        "Mod-u": unorderedListCommand,
+        "Mod-h": headerCommand,
+        "Mod-r": insertCommonmarkHorizontalRuleCommand,
+        "Mod-m": insertCodeblockCommand,
+        "Mod-[": insertTagLinkCommand(parserFeatures.tagLinks.validate, false),
+        "Mod-]": insertTagLinkCommand(parserFeatures.tagLinks.validate, true),
+        "Mod-/": spoilerCommand,
+        "Mod-,": subCommand,
+        "Mod-.": supCommand,
+        "Mod-'": kbdCommand,
         // selectAll selects the outermost node and messes up our other commands
-        ...bindLetterKeymap("Mod-a", selectAllTextCommand),
+        "Mod-a": selectAllTextCommand,
     });
 
-    const tableKeymap = keymap({
-        ...bindLetterKeymap("Mod-e", insertCommonmarkTableCommand),
+    const tableKeymap = caseNormalizeKeymap({
+        "Mod-e": insertCommonmarkTableCommand,
     });
 
-    const keymaps = [commonmarkKeymap, keymap(baseKeymap)];
+    const keymaps = [commonmarkKeymap, caseNormalizeKeymap(baseKeymap)];
 
     if (parserFeatures.tables) {
         keymaps.unshift(tableKeymap);

--- a/src/shared/prosemirror-plugins/case-normalize-keymap.ts
+++ b/src/shared/prosemirror-plugins/case-normalize-keymap.ts
@@ -1,0 +1,33 @@
+import { keydownHandler } from "prosemirror-keymap";
+import { Command, Plugin } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+
+/**
+ * Create a case normalize keymap plugin based on prosemirror-keymap package.
+ * Case sensitivity is normalized based on the status of the shift key (ignoring caps lock key)
+ * @param bindings Object that maps key names to [command](https://prosemirror.net/docs/ref/#commands)-style functions
+ */
+export const caseNormalizeKeymap = (bindings: { [key: string]: Command }) => {
+    const handleKeyDown = (view: EditorView, event: KeyboardEvent): boolean => {
+        let proxyEvent = event;
+
+        // if the key is a letter, we create a copy of the event that maps the key to the
+        // uppercase letter when the shift key is pressed and lowercase when it is not
+        const isKeyLetter = event.key.match(/^[A-Za-z]$/);
+        if (isKeyLetter) {
+            proxyEvent = new KeyboardEvent("keydown", {
+                keyCode: event.keyCode,
+                altKey: event.altKey,
+                ctrlKey: event.ctrlKey,
+                metaKey: event.metaKey,
+                shiftKey: event.shiftKey,
+                key: event.shiftKey
+                    ? event.key.toUpperCase()
+                    : event.key.toLowerCase(),
+            });
+        }
+
+        return keydownHandler(bindings)(view, proxyEvent);
+    };
+    return new Plugin({ props: { handleKeyDown } });
+};

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,5 +1,5 @@
 import { escapeHtml } from "markdown-it/lib/common/utils";
-import { Command, EditorState } from "prosemirror-state";
+import { EditorState } from "prosemirror-state";
 import { error } from "./logger";
 
 /**
@@ -282,33 +282,6 @@ export function dispatchEditorEvent(
 
 /** Helper type that recursively makes an object and all its children Partials */
 export type PartialDeep<T> = { [key in keyof T]?: PartialDeep<T[key]> };
-
-/**
- * Binds a keymap containing a letter to both the lowercase and uppercase version of that letter;
- * this is done so that when the user has CAPS LOCK on, the keymap will still work
- * @param mapping The keymap string to bind
- * @param command The command to bind to all generated keymaps
- */
-export function bindLetterKeymap(
-    mapping: string,
-    command: Command
-): {
-    [key: string]: Command;
-} {
-    const letter = mapping.split("-")[1]?.toLowerCase().trim();
-
-    // not a single letter, so just return the mapping
-    if (!letter || !letter.match(/^[a-z]{1}$/)) {
-        return { [mapping]: command };
-    }
-
-    const prefix = mapping.slice(0, -1);
-
-    return {
-        [prefix + letter]: command,
-        [prefix + letter.toUpperCase()]: command,
-    };
-}
 
 /**
  * Kebab cases a string e.g. "backgroundColor" to "background-color"

--- a/test/shared/prosemirror-plugins/case-normalize-keymap.test.ts
+++ b/test/shared/prosemirror-plugins/case-normalize-keymap.test.ts
@@ -1,0 +1,64 @@
+import { createState, createView } from "../../rich-text/test-helpers";
+import { caseNormalizeKeymap } from "../../../src/shared/prosemirror-plugins/case-normalize-keymap";
+
+describe("case-normalize-keymap", () => {
+    it("should normalize the event with the key letter in lowercase when the shift modifier is NOT pressed", () => {
+        const zLowercaseMockCommand = jest.fn();
+        const zUppercaseMockCommand = jest.fn();
+        const view = createView(
+            createState("", [
+                caseNormalizeKeymap({
+                    z: zLowercaseMockCommand,
+                    Z: zUppercaseMockCommand,
+                }),
+            ])
+        );
+
+        const event = new KeyboardEvent("keydown", {
+            key: "Z",
+        });
+        view.dom.dispatchEvent(event);
+
+        expect(zLowercaseMockCommand).toHaveBeenCalled();
+        expect(zUppercaseMockCommand).not.toHaveBeenCalled();
+    });
+
+    it("should normalize the event with the key letter in uppercase when the shift modifier is pressed", () => {
+        const zLowercaseMockCommand = jest.fn();
+        const zUppercaseMockCommand = jest.fn();
+        const view = createView(
+            createState("", [
+                caseNormalizeKeymap({
+                    z: zLowercaseMockCommand,
+                    Z: zUppercaseMockCommand,
+                }),
+            ])
+        );
+
+        const event = new KeyboardEvent("keydown", {
+            key: "z",
+            shiftKey: true,
+        });
+        view.dom.dispatchEvent(event);
+
+        expect(zLowercaseMockCommand).not.toHaveBeenCalled();
+        expect(zUppercaseMockCommand).toHaveBeenCalled();
+    });
+
+    it("should not normalize keyboard events when their key is not a letter", () => {
+        const mockCommand = jest.fn();
+        const view = createView(
+            createState("", [
+                caseNormalizeKeymap({ "Shift-Enter": mockCommand }),
+            ])
+        );
+
+        const event = new KeyboardEvent("keydown", {
+            key: "Enter",
+            shiftKey: true,
+        });
+        view.dom.dispatchEvent(event);
+
+        expect(mockCommand).toHaveBeenCalled();
+    });
+});

--- a/test/shared/utils.test.ts
+++ b/test/shared/utils.test.ts
@@ -1,5 +1,4 @@
 import {
-    bindLetterKeymap,
     deepMerge,
     escapeHTML,
     stackOverflowValidateLink,
@@ -137,24 +136,6 @@ describe("utils", () => {
         ])("should escape html", (input, output) => {
             expect(escapeHTML`${input}`).toBe(output);
         });
-    });
-
-    describe("bindLetterKeymap", () => {
-        it.each([
-            ["Mod-z", true],
-            ["Mod-Z", true],
-            ["Mod-`", false],
-            ["Mod-Backspace", false],
-        ])(
-            "should double bind lower/upper letter keys",
-            (input, shouldDouble) => {
-                const result = bindLetterKeymap(input, null);
-                const keys = Object.keys(result);
-                expect(keys).toHaveLength(shouldDouble ? 2 : 1);
-                expect(keys).toContain(input);
-                expect(keys[0]).not.toBe(keys[1]);
-            }
-        );
     });
 
     describe("getPlatformModKey", () => {


### PR DESCRIPTION
Closes #187

**Describe your changes**

This PR adds support for `Shift-Mod-Z` as hot key for history redo.
 It removes a utility that was used to create double bindings for both uppercase and lowercase hot keys containing letters (`Mod-z` and `Mod-Z`). 
Instead it introduces a plugin that normalizes letter case for keydown events based on the status of the `Shift` key: 
- when `Shift` is pressed letter case is always uppercase
- when `Shift` is NOT pressed letter case is always lowercase

The plugin also helps to normalize the different Keyboard Events behavior across operative systems when caps lock is enabled. For historical context please refer to this old issue: https://github.com/StackExchange/Stacks-Editor/issues/90

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: PC - OS: Windows 10 - Browser: Chrome
- Device: MacBook Pro - OS: MacOS Monterey - Browser: Chrome, Safari, Firefox, Edge

