### PR TITLE
Add distinct Code of Conduct file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+This project observes the [Stack Exchange Code of Conduct](https://meta.stackexchange.com/conduct). Relevant parts of the Code of Conduct have been copied below. In the event that the content here doesn't match or contradicts the aforementioned Code of Conduct, then the Stack Exchange Code of Conduct takes precedent. Please file an issue against this repo to bring any issues to our attention.
+
+## Our Expectations
+
+- Be clear and constructive when giving feedback, and be open when receiving it.
+- Be inclusive and respectful.
+
+## Unacceptable Behavior
+
+- No subtle put-downs or unfriendly language.
+- No name-calling or personal attacks.
+- No bigotry.
+- No harassment.
+
+## Reporting
+
+- Contact us. https://meta.stackexchange.com/contact

--- a/site/layout.html
+++ b/site/layout.html
@@ -108,6 +108,9 @@
                     <li class="s-menu--title" role="separator">
                         v<span class="js-version-number">???</span>
                     </li>
+                    <li class="s-menu--title tt-unset mt0" role="separator">
+                        Deploys by <a href="https://www.netlify.com">Netlify</a>
+                    </li>
                 </ul>
             </div>
         </nav>


### PR DESCRIPTION
Having a distinct Code of Conduct file is a qualifier for Netlify's [open source plan](https://www.netlify.com/legal/open-source-policy/). We already lay out our code of conduct in the [CONTRIBUTING](https://github.com/StackExchange/Stacks-Editor/blob/main/CONTRIBUTING.md) file, but it doesn't hurt to have it split out as well.

Looking for a quick double check on this - does the content make sense the way I worded it? Once we're happy with the text, I'll copy this file to the other Stacks repos as well.