### PR TITLE
fix(code-blocks): ignore single backticks when copy/pasting code blocks

### DIFF
--- a/src/shared/prosemirror-plugins/code-paste-handler.ts
+++ b/src/shared/prosemirror-plugins/code-paste-handler.ts
@@ -145,15 +145,30 @@ export const commonmarkCodePasteHandler = new Plugin({
                 return false;
             }
 
-            const { $from } = view.state.selection;
+            const { $from, $to } = view.state.selection;
+
+            const isSelectionBetweenBackticks =
+                view.state.doc.textBetween($from.pos - 1, $from.pos) === "`" &&
+                view.state.doc.textBetween($to.pos, $to.pos + 1) === "`";
+
+            const insertionRange = {
+                from: isSelectionBetweenBackticks ? $from.pos - 1 : $from.pos,
+                to: isSelectionBetweenBackticks ? $to.pos + 1 : $to.pos,
+            };
 
             // wrap the code in a markdown code fence
             codeData = "```\n" + codeData + "\n```\n";
 
             // add a newline if we're not at the beginning of the document
-            codeData = ($from.pos === 1 ? "" : "\n") + codeData;
+            codeData = (insertionRange.from === 1 ? "" : "\n") + codeData;
 
-            view.dispatch(view.state.tr.insertText(codeData));
+            view.dispatch(
+                view.state.tr.insertText(
+                    codeData,
+                    insertionRange.from,
+                    insertionRange.to
+                )
+            );
 
             return true;
         },

--- a/test/shared/prosemirror-plugins/code-paste-handler.test.ts
+++ b/test/shared/prosemirror-plugins/code-paste-handler.test.ts
@@ -368,13 +368,13 @@ ${startText.slice(endIndex)}`;
             expect(view.state.doc.textContent).toBe(expected);
         });
 
-        it("should ignore inline code block single backticks when code is pasted between them", () => {
-            let state = createState(`\`your text\``, [
+        it("should ignore inline code block single backticks (and potential whitespaces) when code is pasted between them", () => {
+            let state = createState(`\` your text \``, [
                 commonmarkCodePasteHandler,
             ]);
 
-            // select the inline code block (backticks excluded)
-            state = applySelection(state, 1, 10);
+            // select the text inside the inline code block (backticks and whitespaces excluded)
+            state = applySelection(state, 2, 11);
 
             const view = createView(state);
 

--- a/test/shared/prosemirror-plugins/code-paste-handler.test.ts
+++ b/test/shared/prosemirror-plugins/code-paste-handler.test.ts
@@ -367,5 +367,22 @@ ${startText.slice(endIndex)}`;
 
             expect(view.state.doc.textContent).toBe(expected);
         });
+
+        it("should ignore inline code block single backticks when code is pasted between them", () => {
+            let state = createState(`\`your text\``, [
+                commonmarkCodePasteHandler,
+            ]);
+
+            // select the inline code block (backticks excluded)
+            state = applySelection(state, 1, 10);
+
+            const view = createView(state);
+
+            dispatchPasteEvent(view.dom, {
+                "text/plain": "\tcode",
+            });
+
+            expect(view.state.doc.textContent).toBe("```\n\tcode\n```\n");
+        });
     });
 });


### PR DESCRIPTION
closes https://github.com/StackExchange/Stacks-Editor/issues/230

**Describe your changes**

This PR addresses an issue where users copy/paste "code blocks" (triple backticks delimiter) inside an "inline code block" (single backticks delimiter). For more context about why this user behavior was happening refer to [this meta thread](https://meta.stackoverflow.com/questions/421118/code-blocks-surrounded-by-single-backtick-then-triple-backticks).

The solution solves the issue by checking if the editor view selection is between backticks before appending the clipboard code data. Code feels a bit ad-hoc but I could not find a different way to tackle the issue which would not require large refactors (at least is only 5 extra lines or so). I am open to suggestions.

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

