### PR TITLE
fix(code-block): keep code-block and inline-code menu buttons side by side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@lezer/highlight": "^1.1.3",
                 "@lezer/markdown": "^1.0.2",
                 "@stackoverflow/stacks": "^1.6.7",
-                "@stackoverflow/stacks-icons": "^5.1.0",
+                "@stackoverflow/stacks-icons": "^5.3.1",
                 "@types/markdown-it": "12.2.3",
                 "markdown-it": "^13.0.1",
                 "orderedmap": "^2.1.0",
@@ -1697,9 +1697,9 @@
             }
         },
         "node_modules/@stackoverflow/stacks-icons": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-5.1.0.tgz",
-            "integrity": "sha512-oGwqQcv+6k2YBHtut890UTPHoyQupZO/Ljw+vt1dqhWvivcxp/4H2lQsxlLNeXcTki0f13R/S/95gNJ4FOevqA=="
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-5.3.1.tgz",
+            "integrity": "sha512-WxSc+WzakzNH4cUNVQPvjIQ3NXa7G9CVbT7XovMbyKp3q+cfSpY8sL11RXDtxbAN0FUZ0pq3yHTVoRwVnlXGpQ=="
         },
         "node_modules/@stackoverflow/tsconfig": {
             "version": "1.0.0",
@@ -13412,9 +13412,9 @@
             }
         },
         "@stackoverflow/stacks-icons": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-5.1.0.tgz",
-            "integrity": "sha512-oGwqQcv+6k2YBHtut890UTPHoyQupZO/Ljw+vt1dqhWvivcxp/4H2lQsxlLNeXcTki0f13R/S/95gNJ4FOevqA=="
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-5.3.1.tgz",
+            "integrity": "sha512-WxSc+WzakzNH4cUNVQPvjIQ3NXa7G9CVbT7XovMbyKp3q+cfSpY8sL11RXDtxbAN0FUZ0pq3yHTVoRwVnlXGpQ=="
         },
         "@stackoverflow/tsconfig": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "@lezer/highlight": "^1.1.3",
         "@lezer/markdown": "^1.0.2",
         "@stackoverflow/stacks": "^1.6.7",
-        "@stackoverflow/stacks-icons": "^5.1.0",
+        "@stackoverflow/stacks-icons": "^5.3.1",
         "@types/markdown-it": "12.2.3",
         "markdown-it": "^13.0.1",
         "orderedmap": "^2.1.0",

--- a/src/shared/localization.ts
+++ b/src/shared/localization.ts
@@ -19,7 +19,7 @@ export const defaultStrings = {
         bold: shortcut("Bold"),
         code_block: {
             title: shortcut("Code block"),
-            helpText: "Use for code that is more than one line",
+            help_text: "Use for code that is more than one line",
         },
         emphasis: shortcut("Italic"),
         heading: {

--- a/src/shared/localization.ts
+++ b/src/shared/localization.ts
@@ -19,7 +19,7 @@ export const defaultStrings = {
         bold: shortcut("Bold"),
         code_block: {
             title: shortcut("Code block"),
-            help_text: "Use for code that is more than one line",
+            help_text: "Multiline block of code with syntax highlighting",
         },
         emphasis: shortcut("Italic"),
         heading: {

--- a/src/shared/localization.ts
+++ b/src/shared/localization.ts
@@ -19,7 +19,7 @@ export const defaultStrings = {
         bold: shortcut("Bold"),
         code_block: {
             title: shortcut("Code block"),
-            help_text: "Multiline block of code with syntax highlighting",
+            description: "Multiline block of code with syntax highlighting",
         },
         emphasis: shortcut("Italic"),
         heading: {

--- a/src/shared/localization.ts
+++ b/src/shared/localization.ts
@@ -17,7 +17,10 @@ export const defaultStrings = {
     commands: {
         blockquote: shortcut("Blockquote"),
         bold: shortcut("Bold"),
-        code_block: shortcut("Code block"),
+        code_block: {
+            title: shortcut("Code block"),
+            helpText: "Use for code that is more than one line",
+        },
         emphasis: shortcut("Italic"),
         heading: {
             dropdown: shortcut("Heading"),

--- a/src/shared/localization.ts
+++ b/src/shared/localization.ts
@@ -29,7 +29,10 @@ export const defaultStrings = {
         help: "Help",
         horizontal_rule: shortcut("Horizontal rule"),
         image: shortcut("Image"),
-        inline_code: shortcut("Inline code"),
+        inline_code: {
+            title: shortcut("Inline code"),
+            description: "Single line code span for use within a block of text",
+        },
         kbd: shortcut("Keyboard"),
         link: shortcut("Link"),
         metaTagLink: shortcut("Meta tag"),

--- a/src/shared/menu/entries.ts
+++ b/src/shared/menu/entries.ts
@@ -304,21 +304,6 @@ export const createMenuEntries = (
                     "italic-btn"
                 ),
             },
-            {
-                key: "toggleCode",
-                richText: {
-                    command: toggleMark(schema.marks.code),
-                    active: markActive(schema.marks.code),
-                },
-                commonmark: inlineCodeCommand,
-                display: makeMenuButton(
-                    "Code",
-                    _t("commands.inline_code", {
-                        shortcut: getShortcut("Mod-K"),
-                    }),
-                    "code-btn"
-                ),
-            },
             addIf(
                 {
                     key: "toggleStrike",
@@ -335,6 +320,45 @@ export const createMenuEntries = (
                 },
                 options.parserFeatures?.extraEmphasis
             ),
+        ],
+    },
+    {
+        name: "code-formatting",
+        priority: 5,
+        entries: [
+            {
+                key: "toggleCode",
+                richText: {
+                    command: toggleMark(schema.marks.code),
+                    active: markActive(schema.marks.code),
+                },
+                commonmark: inlineCodeCommand,
+                display: makeMenuButton(
+                    "Code",
+                    _t("commands.inline_code", {
+                        shortcut: getShortcut("Mod-K"),
+                    }),
+                    "code-btn"
+                ),
+            },
+            {
+                key: "toggleCodeblock",
+                richText: {
+                    command: toggleBlockType(schema.nodes.code_block),
+                    active: nodeTypeActive(schema.nodes.code_block),
+                },
+                commonmark: insertCodeblockCommand,
+                display: makeMenuButton(
+                    "CodeblockAlt",
+                    {
+                        title: _t("commands.code_block.title", {
+                            shortcut: getShortcut("Mod-M"),
+                        }),
+                        helpText: _t("commands.code_block.helpText"),
+                    },
+                    "code-block-btn"
+                ),
+            },
         ],
     },
     {
@@ -364,21 +388,6 @@ export const createMenuEntries = (
                         shortcut: getShortcut("Mod-Q"),
                     }),
                     "blockquote-btn"
-                ),
-            },
-            {
-                key: "toggleCodeblock",
-                richText: {
-                    command: toggleBlockType(schema.nodes.code_block),
-                    active: nodeTypeActive(schema.nodes.code_block),
-                },
-                commonmark: insertCodeblockCommand,
-                display: makeMenuButton(
-                    "Codeblock",
-                    _t("commands.code_block", {
-                        shortcut: getShortcut("Mod-M"),
-                    }),
-                    "code-block-btn"
                 ),
             },
             addIf(

--- a/src/shared/menu/entries.ts
+++ b/src/shared/menu/entries.ts
@@ -354,7 +354,7 @@ export const createMenuEntries = (
                         title: _t("commands.code_block.title", {
                             shortcut: getShortcut("Mod-M"),
                         }),
-                        helpText: _t("commands.code_block.help_text"),
+                        description: _t("commands.code_block.description"),
                     },
                     "code-block-btn"
                 ),

--- a/src/shared/menu/entries.ts
+++ b/src/shared/menu/entries.ts
@@ -335,9 +335,12 @@ export const createMenuEntries = (
                 commonmark: inlineCodeCommand,
                 display: makeMenuButton(
                     "Code",
-                    _t("commands.inline_code", {
-                        shortcut: getShortcut("Mod-K"),
-                    }),
+                    {
+                        title: _t("commands.inline_code.title", {
+                            shortcut: getShortcut("Mod-K"),
+                        }),
+                        description: _t("commands.inline_code.description"),
+                    },
                     "code-btn"
                 ),
             },

--- a/src/shared/menu/entries.ts
+++ b/src/shared/menu/entries.ts
@@ -354,7 +354,7 @@ export const createMenuEntries = (
                         title: _t("commands.code_block.title", {
                             shortcut: getShortcut("Mod-M"),
                         }),
-                        helpText: _t("commands.code_block.helpText"),
+                        helpText: _t("commands.code_block.help_text"),
                     },
                     "code-block-btn"
                 ),

--- a/src/shared/menu/helpers.ts
+++ b/src/shared/menu/helpers.ts
@@ -248,7 +248,7 @@ export function makeMenuButton(
     const helpText = typeof content === "string" ? null : content.helpText;
 
     if (helpText) {
-        button.dataset.sTooltipHtmlTitle = `<p class="m0">${title}</p><p class="fs-caption fc-black-600 m0">${helpText}</p>`;
+        button.dataset.sTooltipHtmlTitle = `<p class="mb4">${title}</p><p class="fs-caption fc-black-600 m0">${helpText}</p>`;
     }
 
     button.title = title;

--- a/src/shared/menu/helpers.ts
+++ b/src/shared/menu/helpers.ts
@@ -225,14 +225,15 @@ export function addIf(item: MenuItem, flag: boolean): MenuItem {
 /**
  * Helper function to create consistent menu entry doms
  * @param iconName The html of the svg to use as the icon
- * @param title The text to place in the button's title attribute
+ * @param content Either a string containing the text to place in the button's title attribute
+ * or an object containing the title and helpText to be used in the hover tooltip
  * @param key A unique identifier used for identifying the command to be executed on click
  * @param cssClasses extra CSS classes to be applied to this menu icon (optional)
  * @internal
  */
 export function makeMenuButton(
     iconName: string,
-    title: string,
+    content: string | { title: string; helpText: string },
     key: string,
     cssClasses?: string[]
 ): HTMLButtonElement {
@@ -241,6 +242,13 @@ export function makeMenuButton(
 
     if (cssClasses) {
         button.classList.add(...cssClasses);
+    }
+
+    const title = typeof content === "string" ? content : content.title;
+    const helpText = typeof content === "string" ? null : content.helpText;
+
+    if (helpText) {
+        button.dataset.sTooltipHtmlTitle = `<p class="m0">${title}</p><p class="fs-caption fc-black-600 m0">${helpText}</p>`;
     }
 
     button.title = title;

--- a/src/shared/menu/helpers.ts
+++ b/src/shared/menu/helpers.ts
@@ -254,7 +254,7 @@ export function makeMenuButton(
     }
 
     if (description) {
-        button.dataset.sTooltipHtmlTitle = escapeHTML`<p class="mb4">${title}</p><p class="fs-caption fc-black-600 m0">${description}</p>`;
+        button.dataset.sTooltipHtmlTitle = escapeHTML`<p class="mb4">${title}</p><p class="fs-caption fc-light m0">${description}</p>`;
     }
 
     button.title = title;

--- a/src/shared/menu/helpers.ts
+++ b/src/shared/menu/helpers.ts
@@ -1,5 +1,6 @@
 import { EditorState, Transaction } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
+import { escapeHTML } from "../utils";
 
 /**
  * Callback function signature for all menu entries
@@ -233,7 +234,7 @@ export function addIf(item: MenuItem, flag: boolean): MenuItem {
  */
 export function makeMenuButton(
     iconName: string,
-    content: string | { title: string; helpText: string },
+    content: string | { title: string; description: string },
     key: string,
     cssClasses?: string[]
 ): HTMLButtonElement {
@@ -244,11 +245,16 @@ export function makeMenuButton(
         button.classList.add(...cssClasses);
     }
 
-    const title = typeof content === "string" ? content : content.title;
-    const helpText = typeof content === "string" ? null : content.helpText;
+    let title = content as string;
+    let description = null;
 
-    if (helpText) {
-        button.dataset.sTooltipHtmlTitle = `<p class="mb4">${title}</p><p class="fs-caption fc-black-600 m0">${helpText}</p>`;
+    if (typeof content !== "string") {
+        title = content.title;
+        description = content.description;
+    }
+
+    if (description) {
+        button.dataset.sTooltipHtmlTitle = escapeHTML`<p class="mb4">${title}</p><p class="fs-caption fc-black-600 m0">${description}</p>`;
     }
 
     button.title = title;

--- a/test/shared/menu/helpers.test.ts
+++ b/test/shared/menu/helpers.test.ts
@@ -16,16 +16,28 @@ describe("menu helpers", () => {
         const title = "test title";
         const cssClasses = ["testClass1", "testClass2"];
 
-        const icon = makeMenuButton(iconName, title, key, cssClasses);
-        expect(icon.nodeName).toBe("BUTTON");
-        expect(icon.classList).toContain(`js-${key}`);
-        expect(icon.title).toBe(title);
+        const button = makeMenuButton(iconName, title, key, cssClasses);
+        expect(button.nodeName).toBe("BUTTON");
+        expect(button.classList).toContain(`js-${key}`);
+        expect(button.title).toBe(title);
         (cssClasses || []).forEach((c) => {
-            expect(icon.classList).toContain(c);
+            expect(button.classList).toContain(c);
         });
-        expect(icon.children).toHaveLength(1);
-        expect(icon.firstChild.nodeName).toBe("SPAN");
-        expect(icon.firstElementChild.classList).toContain(`icon${iconName}`);
+        expect(button.children).toHaveLength(1);
+        expect(button.firstChild.nodeName).toBe("SPAN");
+        expect(button.firstElementChild.classList).toContain(`icon${iconName}`);
+        expect(button.dataset.sTooltipHtmlTitle).toBeUndefined();
+    });
+
+    it("should makeMenuButton with title and helpText", () => {
+        const content = { title: "test-title", helpText: "test-help-text" };
+
+        const button = makeMenuButton("testIcon", content, "testKey");
+
+        expect(button.title).toBe(content.title);
+        expect(button.dataset.sTooltipHtmlTitle).toBe(
+            `<p class="m0">${content.title}</p><p class="fs-caption fc-black-600 m0">${content.helpText}</p>`
+        );
     });
 
     it("should makeMenuLinkEntry", () => {

--- a/test/shared/menu/helpers.test.ts
+++ b/test/shared/menu/helpers.test.ts
@@ -35,8 +35,8 @@ describe("menu helpers", () => {
         const button = makeMenuButton("testIcon", content, "testKey");
 
         expect(button.title).toBe(content.title);
-        expect(button.dataset.sTooltipHtmlTitle).toBe(
-            `<p class="m0">${content.title}</p><p class="fs-caption fc-black-600 m0">${content.helpText}</p>`
+        expect(button.dataset.sTooltipHtmlTitle).toMatch(
+            new RegExp(`.*${content.title}.*${content.helpText}.*`)
         );
     });
 

--- a/test/shared/menu/helpers.test.ts
+++ b/test/shared/menu/helpers.test.ts
@@ -29,14 +29,18 @@ describe("menu helpers", () => {
         expect(button.dataset.sTooltipHtmlTitle).toBeUndefined();
     });
 
-    it("should makeMenuButton with title and helpText", () => {
-        const content = { title: "test-title", helpText: "test-help-text" };
+    it("should makeMenuButton with title and description", () => {
+        // add a title/description, checking for XSS protection
+        const content = {
+            title: "test-title",
+            description: "<span>test-help-text</span>",
+        };
 
         const button = makeMenuButton("testIcon", content, "testKey");
 
         expect(button.title).toBe(content.title);
         expect(button.dataset.sTooltipHtmlTitle).toMatch(
-            new RegExp(`.*${content.title}.*${content.helpText}.*`)
+            /test-title.*&lt;span&gt;test-help-text&lt;\/span&gt/
         );
     });
 


### PR DESCRIPTION
This is an attempt to solve the usability issue identified in this meta post: https://meta.stackoverflow.com/questions/422686/code-blocks-surrounded-by-triple-backtick-then-single-backtick

**Describe your changes**
- Replace old `Codeblock` (filled) icon with the new `CodeblockAlt` (outlined) icon
- Create a separate area in the editor menu for code formatting (see mockup)
- Add additional help text in the Code block tooltip (see mockup)

Mockup:
<img width="874" alt="Screenshot 2023-02-03 at 14 15 07" src="https://user-images.githubusercontent.com/6231616/216612593-80e7d60e-265c-44b4-aa64-7fdbeb1a52b0.png">


**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

