### PR TITLE
fix(commonmark): allow shift-enter command

### DIFF
--- a/src/commonmark/key-bindings.ts
+++ b/src/commonmark/key-bindings.ts
@@ -50,6 +50,7 @@ export function allKeymaps(parserFeatures: CommonmarkParserFeatures): Plugin[] {
         "Mod-,": subCommand,
         "Mod-.": supCommand,
         "Mod-'": kbdCommand,
+        "Shift-Enter": baseKeymap["Enter"],
         // selectAll selects the outermost node and messes up our other commands
         "Mod-a": selectAllTextCommand,
     });


### PR DESCRIPTION
Closes #240

## **Describe your changes**

Adds a keybinding for `Shift-Enter` and reuses the existing command bound to `Enter`

## **PR Checklist**

- [ ] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [ ] All new/changed functions have `/** ... */` docs
- [ ] I've added the `bug`/`enhancement` and other labels as appropriate

^ Could use some help with the above.  Not sure we need to super robustly test since we're just exporting an existing command as a new key binding

## **Environment(s) tested**

- Device: Desktop
- OS: Windows
- Browser: Chrome
- Version: 110

## **Additional context**

The default functionality comes from [`prosemirror-commands/src/commands.ts`](https://github.com/ProseMirror/prosemirror-commands/blob/7d895cae5224ad6d5bd6e705878811673b0314f7/src/commands.ts#L691-L692)

```ts
export const pcBaseKeymap: {[key: string]: Command} = {
  "Enter": chainCommands(newlineInCode, createParagraphNear, liftEmptyBlock, splitBlock),
```

Which we import directly into our common mark key-bindings, along with any customizations we might like.  We could probably import the commands `chainCommands`, `newlineInCode`, `createParagraphNear`, `liftEmptyBlock`, `splitBlock` that all get run when the <kbd>Enter</kbd> is pressed, but I think it's easier to just take the built command that's part of the imported `baseKeymap`

## Old Behavior

[![shift-enter-old][1]][1]

## New Behavior

[![shift-enter-new][2]][2]

[1]: https://user-images.githubusercontent.com/4307307/224440792-863f5a47-301e-4fa3-b9b8-b1813cc5b557.gif
[2]: https://user-images.githubusercontent.com/4307307/224440877-d1722a2a-eb4f-4a8a-8402-e01408698d06.gif