### PR TITLE
fix(a11y): accessible mode switcher

### DIFF
--- a/src/stacks-editor/editor.ts
+++ b/src/stacks-editor/editor.ts
@@ -345,13 +345,13 @@ export class StacksEditor implements View {
         const container = document.createElement("div");
         container.className = "flex--item d-flex ai-center ml24 fc-medium";
 
-        container.innerHTML = escapeHTML`<div class="s-btn-group__radio">
+        container.innerHTML = escapeHTML`<div class="s-btn-group s-btn-group--radio fw-nowrap">
     <input type="radio" name="mode-toggle-${this.internalId}"
         id="mode-toggle-rich-${this.internalId}"
-        class="js-editor-toggle-btn"
+        class="s-btn--radio js-editor-toggle-btn"
         data-mode="${EditorType.RichText}"
         ${richCheckedProp} />
-    <label class="s-btn s-editor-btn px6"
+    <label class="s-btn s-btn__muted s-btn__outlined s-editor-btn px6"
         for="mode-toggle-rich-${this.internalId}"
         title="${_t("menubar.mode_toggle_richtext_title")}">
         <span class="svg-icon-bg iconRichText"></span>
@@ -361,11 +361,11 @@ export class StacksEditor implements View {
     </label>
     <input type="radio" name="mode-toggle-${this.internalId}"
         id="mode-toggle-markdown-${this.internalId}"
-        class="js-editor-toggle-btn"
+        class="s-btn--radio js-editor-toggle-btn"
         data-mode="${EditorType.Commonmark}"
         data-preview="false"
         ${markCheckedProp} />
-    <label class="s-btn s-editor-btn px6"
+    <label class="s-btn s-btn__muted s-btn__outlined s-editor-btn px6"
         for="mode-toggle-markdown-${this.internalId}"
         title="${_t("menubar.mode_toggle_markdown_title")}">
         <span class="svg-icon-bg iconMarkdown"></span>
@@ -382,11 +382,11 @@ export class StacksEditor implements View {
             tmp.innerHTML = escapeHTML`
 <input type="radio" name="mode-toggle-${this.internalId}"
     id="mode-toggle-preview-${this.internalId}"
-    class="js-editor-toggle-btn"
+    class="s-btn--radio js-editor-toggle-btn"
     data-mode="${EditorType.Commonmark}"
     data-preview="${previewEnabled.toString()}"
     ${previewCheckedProp} />
-<label class="s-btn s-editor-btn px6"
+<label class="s-btn s-btn__muted s-btn__outlined s-editor-btn px6"
     for="mode-toggle-preview-${this.internalId}"
     title="${_t("menubar.mode_toggle_preview_title")}">
     <span class="svg-icon-bg iconMarkdownPreview"></span>
@@ -447,8 +447,5 @@ export class StacksEditor implements View {
             previewShown:
                 this.currentViewType !== EditorType.RichText && showPreview,
         });
-
-        // TODO do we always want to focus the editor?
-        this.focus();
     }
 }


### PR DESCRIPTION
Closes [Stacks-286](https://stackoverflow.atlassian.net/browse/STACKS-286)

**Describe your changes**

This PR updates the mode switcher to use the [Stacks `.s-btn-group--radio` variant syntax](https://stackoverflow.design/product/components/button-groups/#radio), which is keyboard navigable.

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: MacBook Pro
- OS: Mac OS 13.0.1
- Browser Firefox, Chrome

**Additional context**

This PR also remove auto-focusing the editor frame on mode switching for ergonomics/accessibility.
