### PR TITLE
fix(a11y): remove illegal (and superfluous) aria role from the image uploader browse label

### DIFF
--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -139,7 +139,7 @@ export class ImageUploader extends PluginInterfaceView<
         // TODO i18n
         this.uploadContainer.innerHTML = escapeHTML`
             <div class="fs-body2 p12 pb0 js-cta-container">
-                <label for="${this.uploadField.id}" class="d-inline-flex f:outline-ring s-link js-browse-button" role="button" aria-controls="image-preview-${randomId}">
+                <label for="${this.uploadField.id}" class="d-inline-flex f:outline-ring s-link js-browse-button" aria-controls="image-preview-${randomId}">
                     Browse
                 </label>, drag & drop<span class="js-external-url-trigger-container d-none">, <button type="button" class="s-btn s-btn__link js-external-url-trigger">enter a link</button></span>, or paste an image <span class="fc-light fs-caption">Max size 2 MiB</span>
             </div>


### PR DESCRIPTION
TEAMS-9651, items 2005562 and 2005563

This was called out in an accessibility audit. A label can't have a button role, and it's not necessary anyway -- since it labels the "choose file" button, it's announced as a button even without this role. I confirmed this with NVDA/Chrome.
