### PR TITLE
PoC for intercepting image uploads

### DIFF
--- a/site/views/intercept-image.html
+++ b/site/views/intercept-image.html
@@ -1,0 +1,24 @@
+{% layout "layout.html" %} {% block content %}
+<textarea id="content" name="content" class="d-none">
+Upload an image via the menu item above in rich-text mode.
+</textarea>
+<h1 class="mt32">Intercept Image Flow</h1>
+<div id="example-1" class="js-tables-enabled js-intercept-image"></div>
+
+<aside class="s-modal js-intercept-image-modal" role="dialog" aria-labelledby="intercept-image-modal-title"
+    aria-describedby="intercept-image-modal-description" aria-hidden="true" data-controller="s-modal"
+    data-s-modal-target="modal">
+    <div class="s-modal--dialog" role="document">
+        <h1 class="s-modal--header" id="intercept-image-modal-title">This image has been intercepted</h1>
+        <img class="js-intercept-image-preview d-block w100 mb24" alt="image preview" />
+        <p class="s-modal--body" id="intercept-image-modal-description">
+            Do you want to detect code from the image and add that in a code block?</p>
+        <div class="d-flex gx8 s-modal--footer">
+            <button class="flex--item s-btn s-btn__primary js-intercept-image-scan" type="button">Yes, insert
+                formatted code</button>
+            <button class="flex--item s-btn js-intercept-image-cancel-scan" type="button">No, upload the
+                image as is</button>
+        </div>
+    </div>
+</aside>
+{% endblock %}


### PR DESCRIPTION
This PoC explore how we could leverage the existing `ImageUploadOptions["handler"]` to intercept image uploads and show a prompt to the user to swap images with detected text. 

## How to test:
- Start the webpack dev server `npm start`
- Visit `http://localhost:8080/intercept-image.html`
- Make sure you are on rich text mode
- Click on the image menu item
- Add an image
- See modal popping up

## Known issue
It is not possible to inject data to the editor directly from the handler
See issue in code: https://github.com/StackExchange/Stacks-Editor/compare/STACKS-310/intercept-image-flow-poc?expand=1#diff-be39fdbd3dacf49598cf929839b9ab9e1629658c2195c2d8b04826da45ca678cR176

## Possible solutions (need discovery)
- Hide the image menu item and build a brand new editor plugin to achieve exactly what needed
- Expand the `ImageUploadOptions` interface to support injecting data into the editor