### PR TITLE
Image upload intercept plugin

### DIFF
--- a/site/sample-plugins/image-intercept.ts
+++ b/site/sample-plugins/image-intercept.ts
@@ -1,0 +1,60 @@
+import { Plugin, PluginView } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+import type { EditorPlugin } from "../../src";
+
+const plugin = new Plugin({
+    view(view) {
+        return new InterceptView(view);
+    },
+});
+
+class InterceptView implements PluginView {
+    private listener: (
+        this: InterceptView,
+        e: CustomEvent<{ file: File }>
+    ) => void;
+
+    constructor(private view: EditorView) {
+        this.listener = function (
+            this: InterceptView,
+            e: CustomEvent<{ file: File }>
+        ) {
+            // eslint-disable-next-line no-alert
+            const intercept = window.confirm(
+                "We have detected code in this image. Would you like to extract it?"
+            );
+
+            // user chose not to intercept, just return
+            if (!intercept) {
+                return;
+            }
+
+            // cancel the event so the image is not uploaded - we'll handle it
+            e.preventDefault();
+
+            let tr = view.state.tr;
+
+            // insert a code block
+            tr = tr.insert(
+                tr.selection.from,
+                view.state.schema.nodes.code_block.create(
+                    {},
+                    view.state.schema.text(`console.log('Hello World!')`)
+                )
+            );
+
+            view.dispatch(tr);
+        }.bind(this);
+
+        view.dom.addEventListener("StacksEditor:image-upload", this.listener);
+    }
+    destroy() {
+        this.view.dom.removeEventListener("", this.listener);
+    }
+}
+
+export const imageInterceptPlugin: EditorPlugin = () => ({
+    richText: {
+        plugins: [plugin],
+    },
+});

--- a/site/sample-plugins/index.ts
+++ b/site/sample-plugins/index.ts
@@ -1,5 +1,11 @@
+import { imageInterceptPlugin } from "./image-intercept";
 import { japaneseSEPlugin } from "./japanese-se";
 import { mermaidPlugin } from "./mermaid";
 import { sillyPlugin } from "./silly-effects";
 
-export const samplePlugins = [japaneseSEPlugin, mermaidPlugin, sillyPlugin];
+export const samplePlugins = [
+    japaneseSEPlugin,
+    mermaidPlugin,
+    sillyPlugin,
+    imageInterceptPlugin,
+];

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -9,7 +9,7 @@ import { NodeSpec, Schema } from "prosemirror-model";
 import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { CommonmarkParserFeatures } from "../view";
 import { StatefulPlugin } from "./plugin-extensions";
-import { escapeHTML, generateRandomId } from "../utils";
+import { dispatchEditorEvent, escapeHTML, generateRandomId } from "../utils";
 import { _t } from "../localization";
 import { ManagedInterfaceKey, PluginInterfaceView } from "./interface-manager";
 
@@ -455,7 +455,14 @@ export class ImageUploader extends PluginInterfaceView<
             return;
         }
 
-        void this.startImageUpload(view, file || externalUrl);
+        const uncanceled = dispatchEditorEvent(view.dom, "image-upload", {
+            file,
+        });
+
+        if (uncanceled) {
+            void this.startImageUpload(view, file || externalUrl);
+        }
+
         this.resetUploader();
         const tr = this.tryHideInterfaceTr(view.state);
         if (tr) {


### PR DESCRIPTION
Very basic sample plugin that shows how one might listen to, intercept and handle editor events. PR built in response to suggestion in #247.