### PR TITLE
feat(image-upload): dispatch event for intercepting image upload flow

### DIFF
--- a/site/sample-plugins/code-detection.ts
+++ b/site/sample-plugins/code-detection.ts
@@ -1,0 +1,84 @@
+import { Plugin, PluginView } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+import type { EditorPlugin } from "../../src";
+
+type InterceptImageUploadEvent = CustomEvent<{
+    file: File;
+    resume: (resume: boolean) => void;
+}>;
+
+class InterceptImageUploadView implements PluginView {
+    private listener: (e: InterceptImageUploadEvent) => void;
+
+    constructor(private view: EditorView) {
+        this.listener = (e: InterceptImageUploadEvent) =>
+            void (async () => {
+                // pause the regular flow so that the image is not uploaded
+                // we can resume it by calling e.detail.resume(true) later on
+                e.preventDefault();
+
+                // simulation of a call to code detection API
+                const code: string = await new Promise((resolve) =>
+                    setTimeout(
+                        () => resolve(`console.log('Hello World!'`),
+                        1000
+                    )
+                );
+
+                // no code detected, resume the regular image upload
+                if (!code) {
+                    e.detail.resume(true);
+                    return;
+                }
+
+                // code is detected in the image, ask the user if they want to insert the code instead
+                // eslint-disable-next-line no-alert
+                const insertCode = window.confirm(
+                    "We have detected code in this image. Would you like to extract it?"
+                );
+
+                // user chose not to insert the code - resume the regular image upload
+                if (!insertCode) {
+                    e.detail.resume(true);
+                    return;
+                }
+
+                // user chose to insert the code - don't resume image upload
+                e.detail.resume(false);
+
+                let tr = view.state.tr;
+
+                // insert the code in a code block
+                tr = tr.insert(
+                    tr.selection.from,
+                    view.state.schema.nodes.code_block.create(
+                        {},
+                        view.state.schema.text(code)
+                    )
+                );
+
+                view.dispatch(tr);
+            })();
+
+        view.dom.addEventListener("StacksEditor:image-upload", this.listener);
+    }
+
+    destroy() {
+        this.view.dom.removeEventListener(
+            "StacksEditor:image-upload",
+            this.listener
+        );
+    }
+}
+
+const plugin = new Plugin({
+    view(view) {
+        return new InterceptImageUploadView(view);
+    },
+});
+
+export const codeDetectionPlugin: EditorPlugin = () => ({
+    richText: {
+        plugins: [plugin],
+    },
+});

--- a/site/sample-plugins/index.ts
+++ b/site/sample-plugins/index.ts
@@ -1,5 +1,11 @@
 import { japaneseSEPlugin } from "./japanese-se";
 import { mermaidPlugin } from "./mermaid";
 import { sillyPlugin } from "./silly-effects";
+import { codeDetectionPlugin } from "./code-detection";
 
-export const samplePlugins = [japaneseSEPlugin, mermaidPlugin, sillyPlugin];
+export const samplePlugins = [
+    japaneseSEPlugin,
+    mermaidPlugin,
+    sillyPlugin,
+    codeDetectionPlugin,
+];

--- a/site/views/plugins.html
+++ b/site/views/plugins.html
@@ -2,8 +2,8 @@
 <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 
 <textarea id="content" class="d-none">
-There is **code detection plugin** active in this editor that will intercept image uploads and try to detect if they are code.<br />
-If they are, it will ask the user if they want to upload them as a code block instead of an image.
+There is a **code detection plugin** active in this editor that will intercept image uploads and simulate image code detection.<br />
+If code is detected, the plugin will ask the user if they want to upload images as a code block instead of an image.
 Try it out by clicking the image menu item above 🏞️.
 
 <hr />

--- a/site/views/plugins.html
+++ b/site/views/plugins.html
@@ -2,6 +2,12 @@
 <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 
 <textarea id="content" class="d-none">
+There is **code detection plugin** active in this editor that will intercept image uploads and try to detect if they are code.<br />
+If they are, it will ask the user if they want to upload them as a code block instead of an image.
+Try it out by clicking the image menu item above 🏞️.
+
+<hr />
+
 Here's a plugin that adds mermaid graph support:
 
 ```mermaid

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -640,7 +640,7 @@ export function imageUploaderEnabled(state: EditorState): boolean {
  */
 function createPlaceholder(): HTMLDivElement {
     const placeholder = document.createElement("div");
-    placeholder.className = "ws-normal d-block m8";
+    placeholder.className = "ws-normal d-block m8 js-image-upload-placeholder";
     placeholder.innerHTML = `
 <div class="py6 px6 bg-black-050 bar-sm gsx gs8 d-inline-flex ai-center fw-normal fs-body1">
     <span class="s-spinner s-spinner__sm flex--item">


### PR DESCRIPTION
## Summary
Dispatch a custom event on image upload to allow plugin authors to pause the upload flow and decide to either abort or resume it based on async operations. 

## How to test
- Visit `http://localhost:8080/plugins.html` or the [PR deploy preview](https://deploy-preview-249--stacks-editor.netlify.app/plugins.html)
- Upload an image in rich-text or commonmark mode
- A confirmation dialog should appear saying that code was detected in the image
- Click ok and observe a codeblock being inserted in the editor as opposed to the image being uploaded

## Open Todos
- [x] review solution design 
- [x] write unit tests
- [x] cleanup demo plugin showcasing the feature
