### PR TITLE
feat: allow for the option of showing a warning in the image upload plugin

### DIFF
--- a/site/index.ts
+++ b/site/index.ts
@@ -200,6 +200,7 @@ domReady(() => {
             "These images are uploaded nowhere, so no content policy applies",
         wrapImagesInLinks: true,
         allowExternalUrls: true,
+        warningMessage: enableSamplePlugin ? "Images are useful in a post, but <strong>make sure the post is still clear without them</strong>.  If you post images of code or error messages, copy and paste or type the actual code or message into the post directly." : null
     };
 
     // TODO should null out entire object, but that currently just defaults back to the original on merge

--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -52,6 +52,10 @@ export interface ImageUploadOptions {
      * If true, allow users to add images via an external url
      */
     allowExternalUrls?: boolean;
+    /*
+     * If provided, will display this warning message at the top of the image upload menu
+     */
+    warningMessage?: string;
 }
 
 /**
@@ -138,6 +142,8 @@ export class ImageUploader extends PluginInterfaceView<
 
         // TODO i18n
         this.uploadContainer.innerHTML = escapeHTML`
+            <div class="s-notice s-notice__warning m16 mb0 js-upload-warning d-none"></div>
+
             <div class="fs-body2 p12 pb0 js-cta-container">
                 <label for="${this.uploadField.id}" class="d-inline-flex f:outline-ring s-link js-browse-button" aria-controls="image-preview-${randomId}">
                     Browse
@@ -234,6 +240,15 @@ export class ImageUploader extends PluginInterfaceView<
                 void this.handleUploadTrigger(e, this.image, view);
             });
 
+        if (this.uploadOptions?.warningMessage) {
+            const warning = this.uploadContainer.querySelector(".js-upload-warning");
+            warning.classList.remove("d-none");
+            
+            // XSS "safe": this html is passed in via the editor options; it is not our job to sanitize it
+            // eslint-disable-next-line no-unsanitized/property
+            warning.innerHTML = this.uploadOptions?.warningMessage;
+        }
+        
         if (this.uploadOptions.allowExternalUrls) {
             this.uploadContainer
                 .querySelector(".js-external-url-trigger-container")

--- a/test/shared/prosemirror-plugins/image-upload.test.ts
+++ b/test/shared/prosemirror-plugins/image-upload.test.ts
@@ -45,6 +45,29 @@ describe("image upload plugin", () => {
 
             expect(updatedUploadContainer.parentElement).toBeTruthy();
         });
+        
+        it("should have warning hidden by default", () => {
+            expect(uploader.uploadContainer.parentElement).toBeNull();
+
+            showImageUploader(view.editorView);
+            const warningDiv =
+                pluginContainer.querySelector(".js-upload-warning");
+
+            expect(warningDiv.classList.contains("d-none")).toBeTruthy();
+        });
+
+        it("should have warning shown with proper text when option provided", () => {
+            const warningText = "this is <strong>warning</strong> test";
+            setupTestVariables({warningMessage: warningText});
+
+            expect(uploader.uploadContainer.parentElement).toBeNull();
+            showImageUploader(view.editorView);
+            const warningDiv =
+                pluginContainer.querySelector(".js-upload-warning");
+
+            expect(warningDiv.classList.contains("d-none")).toBeFalsy();
+            expect(warningDiv.innerHTML).toEqual(warningText);
+        });
 
         it("should focus 'browse' button when showing image uploader", () => {
             // we need to add our DOM to the doc's body in order to make jsdom's "focus" handling work
@@ -78,6 +101,7 @@ describe("image upload plugin", () => {
         });
 
         it("should disable 'add image' button without preview", () => {
+            
             showImageUploader(view.editorView);
 
             const addButton = findAddButton(uploader);


### PR DESCRIPTION
**Describe your changes**

- Adds a `warningMessage` property to the image upload options
- When this property is set, will display the text in a `s-notice s-notice__warning` with the same setup as is used for the old editor
- Assumes that the text provided has been sanitized, per conventions used elsewhere

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

**Additional context**

Addresses: [MSO: Ask Wizard does not show the warning about images of code or errors](https://meta.stackoverflow.com/questions/424646/ask-wizard-does-not-show-the-warning-about-images-of-code-or-errors)

It is setup for viewing in the Plugin Playground example page:

![image](https://github.com/StackExchange/Stacks-Editor/assets/1366941/ba6c56a6-82a1-4154-8ec0-4a7bc1a1a08c)

