### PR TITLE
fix(a11y): add menuitem role to menu buttons

### DIFF
--- a/src/shared/menu/plugin.ts
+++ b/src/shared/menu/plugin.ts
@@ -319,6 +319,7 @@ export class MenuView implements PluginView {
         button.setAttribute("aria-controls", popoverId);
         button.setAttribute("data-action", "s-popover#toggle");
         button.setAttribute("data-controller", "s-tooltip");
+        button.setAttribute("role", "menuitem");
         button.id = buttonId;
         button.dataset.key = entry.key;
 
@@ -329,6 +330,7 @@ export class MenuView implements PluginView {
 
         const arrow = document.createElement("div");
         arrow.className = "s-popover--arrow";
+        arrow.setAttribute("aria-hidden", "true");
 
         popover.appendChild(arrow);
 


### PR DESCRIPTION
Closes [STACKS-382](https://stackoverflow.atlassian.net/browse/STACKS-382)


This PR adds `role="menuitem"` to buttons within a toolbar menu. It also adds `aria-hidden="true"` to the popover arrow since it's purely decorative.