### PR TITLE
fix(a11y): prevent refocus of textarea on keyboard navigation

### DIFF
--- a/src/shared/menu/helpers.ts
+++ b/src/shared/menu/helpers.ts
@@ -199,7 +199,6 @@ export function makeDropdownItem(
     button.type = "button";
     button.dataset.key = key;
     button.textContent = title;
-    button.dataset.action = "s-popover#hide";
     button.setAttribute("role", "menuitem");
     button.className = `s-block-link s-editor--dropdown-item js-editor-btn`;
 

--- a/src/shared/menu/plugin.ts
+++ b/src/shared/menu/plugin.ts
@@ -112,7 +112,22 @@ export class MenuView implements PluginView {
             const key = (target as HTMLElement).dataset.key;
 
             e.preventDefault();
+            const isMouseEvent = e.detail > 0; // See https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
 
+            // Move focus to the editor exclusively for mouse clicks
+            // For keyboard events, we keep the focus on the menubar
+            if (isMouseEvent) {
+                // When the click is from a menuitem, hide the popover
+                if (target.getAttribute("role") === "menuitem") {
+                    const menuButton = (<HTMLElement>e.target).closest(
+                        '[data-controller="s-popover"]'
+                    );
+                    hidePopover(menuButton);
+                }
+
+                // leave the menubar and focus on the editor
+                view.focus();
+            }
             // Conditional added to only focus view on mouse events, so keyboard navigation remains intact
             // See https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
             if (e.detail > 0) {

--- a/src/shared/menu/plugin.ts
+++ b/src/shared/menu/plugin.ts
@@ -112,7 +112,18 @@ export class MenuView implements PluginView {
             const key = (target as HTMLElement).dataset.key;
 
             e.preventDefault();
-            view.focus();
+
+            // Conditional added to only focus view on mouse events, so keyboard navigation remains intact
+            // See https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
+            if (e.detail > 0) {
+                // Hide the menu popover if it's visible
+                const menu = (<HTMLElement>e.target).closest(".s-popover");
+                if (target.getAttribute("role") === "menuitem" && menu) {
+                    menu?.classList.remove("is-visible");
+                    target.setAttribute("aria-expanded", "false");
+                }
+                view.focus();
+            }
 
             const found = menuCommands.find((c) => c.key === key);
             const foundCommand = this.command(found);
@@ -319,7 +330,7 @@ export class MenuView implements PluginView {
         button.setAttribute("aria-controls", popoverId);
         button.setAttribute("data-action", "s-popover#toggle");
         button.setAttribute("data-controller", "s-tooltip");
-        button.setAttribute("role", "menuitem");
+        button.setAttribute("role", "menu");
         button.id = buttonId;
         button.dataset.key = entry.key;
 

--- a/src/shared/menu/plugin.ts
+++ b/src/shared/menu/plugin.ts
@@ -15,6 +15,7 @@ import {
     MenuCommand,
     makeMenuButton,
 } from "./helpers";
+import { hidePopover } from "@stackoverflow/stacks";
 
 /** NoOp to use in place of missing commands */
 const commandNoOp = () => false;
@@ -128,17 +129,17 @@ export class MenuView implements PluginView {
                 // leave the menubar and focus on the editor
                 view.focus();
             }
-            // Conditional added to only focus view on mouse events, so keyboard navigation remains intact
-            // See https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
-            if (e.detail > 0) {
-                // Hide the menu popover if it's visible
-                const menu = (<HTMLElement>e.target).closest(".s-popover");
-                if (target.getAttribute("role") === "menuitem" && menu) {
-                    menu?.classList.remove("is-visible");
-                    target.setAttribute("aria-expanded", "false");
-                }
-                view.focus();
-            }
+            // // Conditional added to only focus view on mouse events, so keyboard navigation remains intact
+            // // See https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
+            // if (e.detail > 0) {
+            //     // Hide the menu popover if it's visible
+            //     const menu = (<HTMLElement>e.target).closest(".s-popover");
+            //     if (target.getAttribute("role") === "menuitem" && menu) {
+            //         menu?.classList.remove("is-visible");
+            //         target.setAttribute("aria-expanded", "false");
+            //     }
+            //     view.focus();
+            // }
 
             const found = menuCommands.find((c) => c.key === key);
             const foundCommand = this.command(found);

--- a/src/shared/menu/plugin.ts
+++ b/src/shared/menu/plugin.ts
@@ -129,17 +129,6 @@ export class MenuView implements PluginView {
                 // leave the menubar and focus on the editor
                 view.focus();
             }
-            // // Conditional added to only focus view on mouse events, so keyboard navigation remains intact
-            // // See https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
-            // if (e.detail > 0) {
-            //     // Hide the menu popover if it's visible
-            //     const menu = (<HTMLElement>e.target).closest(".s-popover");
-            //     if (target.getAttribute("role") === "menuitem" && menu) {
-            //         menu?.classList.remove("is-visible");
-            //         target.setAttribute("aria-expanded", "false");
-            //     }
-            //     view.focus();
-            // }
 
             const found = menuCommands.find((c) => c.key === key);
             const foundCommand = this.command(found);

--- a/test/commonmark/editor.e2e.test.ts
+++ b/test/commonmark/editor.e2e.test.ts
@@ -81,7 +81,7 @@ test.describe.serial("markdown mode", () => {
         await page.focus(moreMenuDropdownSelector);
         const moreDropdownBtnIsFocused = await page.evaluate(() =>
             document
-                .querySelector(moreMenuDropdownSelector)
+                .querySelector(".js-more-formatting-dropdown")
                 ?.isEqualNode(document.activeElement)
         );
         expect(moreDropdownBtnIsFocused).toBe(true);

--- a/test/commonmark/editor.e2e.test.ts
+++ b/test/commonmark/editor.e2e.test.ts
@@ -8,6 +8,7 @@ import {
     clickEditorContent,
 } from "../e2e-helpers";
 
+const moreMenuDropdownSelector = ".js-more-formatting-dropdown";
 const boldMenuButtonSelector = ".js-bold-btn";
 
 test.describe.serial("markdown mode", () => {
@@ -69,5 +70,42 @@ test.describe.serial("markdown mode", () => {
 
         // On some OSes (Windows 10 at least), the selection excludes the trailing newline
         expect(selectedText).toMatch(/^# Heading 1\n?$/);
+    });
+
+    test("should retain focus on the menu item after triggering via keyboard", async ({
+        page,
+    }) => {
+        await expect(page.locator(moreMenuDropdownSelector)).toBeInViewport();
+
+        // Focus the dropdown
+        await page.focus(moreMenuDropdownSelector);
+        const moreDropdownBtnIsFocused = await page.evaluate(() =>
+            document
+                .querySelector(moreMenuDropdownSelector)
+                ?.isEqualNode(document.activeElement)
+        );
+        expect(moreDropdownBtnIsFocused).toBe(true);
+
+        // Open the dropdown
+        await page.keyboard.press("Enter");
+
+        // Tab to "Spoiler (Cmd-/)"
+        await page.keyboard.press("Tab");
+        await page.keyboard.press("Tab");
+        await page.keyboard.press("Tab");
+
+        const activeElementDataKey = await page.evaluate(() =>
+            document.activeElement.getAttribute("data-key")
+        );
+        expect(activeElementDataKey).toBe("spoiler-btn");
+
+        // Trigger the menu item via keyboard
+        await page.keyboard.press("Enter");
+
+        // Ensure the menu item retains focus after triggering via keyboard
+        const newActiveElementDataKey = await page.evaluate(() =>
+            document.activeElement.getAttribute("data-key")
+        );
+        expect(newActiveElementDataKey).toBe("spoiler-btn");
     });
 });


### PR DESCRIPTION
Closes [STACKS-383](https://stackoverflow.atlassian.net/browse/STACKS-383)

This PR ensures that the focused editor menu element retains focus when navigating via keyboard.

Previously, tabbing to a menu element then invoking it with <kbd>enter</kbd> would send focus to the "view" (aka the textarea). This would require those navigating with the keyboard to have to tab back to where they were to continue where they left off. This PR addresses this issue with the following changes:

1. Focus is no longer moved to the view unless editor menu item was clicked
2. The popover is only hidden if the popover menu item was clicked

### TODO
- [x] Add unit test
- [x] Add ticket(s) for fully accessible menu (see https://github.com/StackExchange/Stacks-Editor/pull/254#pullrequestreview-1624199129) https://stackoverflow.atlassian.net/browse/STACKS-402