### PR TITLE
refactor(hljs): make hljs import for development environments ESM friendly

### DIFF
--- a/src/shared/highlighting/hljs-instance.ts
+++ b/src/shared/highlighting/hljs-instance.ts
@@ -1,24 +1,15 @@
-import type { HLJSApi } from "highlight.js";
+import hljs, { type HLJSApi } from "highlight.js";
 
-/* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/ban-ts-comment */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 /*
  * NOTE: This file is only for local development / generic bundles
  * The prod/stackoverflow build configs completely remove highlight.js from the bundle,
  * expecting it to be supplied globally as `window.hljs`, already configured and ready to go
  */
 
-/** Attempts to get the optional highlight.js instance */
 export function getHljsInstance(): HLJSApi {
     // @ts-expect-error
-    let hljs: HLJSApi = globalThis.hljs as HLJSApi;
+    const hljsInstance: HLJSApi = (globalThis.hljs as HLJSApi) ?? hljs;
 
-    if (!hljs) {
-        try {
-            hljs = require("highlight.js") as HLJSApi;
-        } catch {
-            // Failed to import optional dependency. Do nothing :)
-        }
-    }
-
-    return hljs && hljs.highlight ? hljs : null;
+    return hljsInstance && hljsInstance.highlight ? hljsInstance : null;
 }


### PR DESCRIPTION
[STACKS-346](https://stackoverflow.atlassian.net/browse/STACKS-346)

**Describe your changes**

@stackoverflow/stacks-editor has a [reference](https://github.com/StackExchange/Stacks-Editor/blob/main/src/shared/highlighting/hljs-instance.ts#L17) to `require` for local developement environments which should be swapped with something ESM friendly like dynamic imports. This will allow ESM first tools such as vitest (and vite-node) to run smoothly when they are importing the editor.

Since webpack will exclude `highlightjs` at build time for production bundle there is no need of using dynamic import (which would have required to make the function async). Instead we can simply import `highlightjs` with a regular ESM import.

**How to test**

- Run `npm i`
- Run `npm run build` and check on webpack output that hljs is still excluded from the production bundle (app.bundle.js should remain 573KiB)
- Run `npm start` and make sure `hljs` still works for code blocks locally (http://localhost:8080)
