### PR TITLE
fix(a11y): use disabled attribute instead of .is-disabled

### DIFF
--- a/src/shared/menu/plugin.ts
+++ b/src/shared/menu/plugin.ts
@@ -46,7 +46,6 @@ export class MenuView implements PluginView {
     private readonly: boolean;
     private editorType: EditorType;
 
-    static disabledClass = "is-disabled";
     static activeClass = "is-selected";
     static invisibleClass = "d-none";
 
@@ -106,7 +105,7 @@ export class MenuView implements PluginView {
             }
 
             // if the button is "disabled", return early
-            if (target.classList.contains(MenuView.disabledClass)) {
+            if (target.hasAttribute("disabled")) {
                 return;
             }
 
@@ -226,9 +225,9 @@ export class MenuView implements PluginView {
             !isReadonly &&
             command.command(this.view.state, undefined, this.view);
 
-        dom.classList.remove(MenuView.disabledClass);
         dom.classList.remove(MenuView.activeClass);
         dom.classList.remove(MenuView.invisibleClass);
+        dom.removeAttribute("disabled");
 
         dom.dataset.key = entry.key;
 
@@ -238,7 +237,7 @@ export class MenuView implements PluginView {
         } else if (active) {
             dom.classList.add(MenuView.activeClass);
         } else if (!enabled) {
-            dom.classList.add(MenuView.disabledClass);
+            dom.setAttribute("disabled", "");
         }
 
         // if this is a dropdown, check all of its children as well

--- a/src/styles/custom-components.css
+++ b/src/styles/custom-components.css
@@ -123,11 +123,6 @@
     color: var(--theme-secondary-500) !important;
 }
 
-.s-btn.s-editor-btn.is-disabled {
-    background-color: transparent !important;
-    opacity: 0.5;
-}
-
 .s-btn.s-editor-btn.s-btn__dropdown {
     padding-right: var(--su12);
 }
@@ -150,7 +145,7 @@
     font-weight: 400;
 }
 
-.s-editor--dropdown-item.is-disabled {
+.s-editor--dropdown-item[disabled] {
     opacity: 0.5;
 }
 

--- a/test/shared/menu/plugin.test.ts
+++ b/test/shared/menu/plugin.test.ts
@@ -177,7 +177,8 @@ describe("menu plugin view", () => {
         expect(activeCommand(view.state)).toBe(false);
 
         let item = getItem();
-        expect(item.classList).not.toContain("is-disabled");
+        expect(item.attributes).not.toHaveProperty("disabled");
+        expect(item.attributes).not.toContain("disabled");
         expect(item.classList).not.toContain("is-selected");
         expect(item.classList).not.toContain("d-none");
 
@@ -197,7 +198,7 @@ describe("menu plugin view", () => {
         view.updateState(setDisabled(view.state));
         expect(enabledCommand(view.state, null)).toBe(false);
         item = getItem();
-        expect(item.classList).toContain("is-disabled");
+        expect(item.attributes).toHaveProperty("disabled");
     });
 
     it.todo("should dispatch an item's command when clicked");


### PR DESCRIPTION
**Describe your changes**

This change came from some issues I noticed while reviewing https://github.com/StackExchange/Stacks-Editor/pull/259. I took this opportunity to replace uses of `.is-disabled` with the `disabled` attribute which is ensures that disabled editor buttons act in accordance with our expectation of disabled UI. It has the added benefit of allowing us to some custom CSS, since Stacks buttons apply the expected styling on disabled buttons by targeting the `disabled` attribute.

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

@giamir I've opened this PR because I think it is fine to be reviewed, but no rush on this. It's just some work I performed in the process of reviewing https://github.com/StackExchange/Stacks-Editor/pull/259 and I felt was worth capturing.
