### PR TITLE
fix(autoformatting): prevent autoformatting when the first underscore is preceded by a non-whitespace character

### DIFF
--- a/src/rich-text/inputrules.ts
+++ b/src/rich-text/inputrules.ts
@@ -17,7 +17,7 @@ export const emphasisRegexAsterisk = /\*([^*\s]([^*])*[^*\s]|[^*\s])\*$/;
 // matches: __some text__, but not __ text __
 const strongRegexUnderscores = /__(\S(?:|.*?\S))__$/;
 // matches: _some text_, but not __text_ or _ text _
-const emphasisRegexUnderscore = /_([^_\s]([^_])*[^_\s]|[^_\s])_$/;
+const emphasisRegexUnderscore = /(?<!\S)_([^_\s]([^_])*[^_\s]|[^_\s])_$/;
 // matches: [ *any* thing ]( any thing )
 const linkRegex = /\[(.+)\]\((.+)\)$/;
 

--- a/src/rich-text/inputrules.ts
+++ b/src/rich-text/inputrules.ts
@@ -15,7 +15,7 @@ const strongRegexAsterisks = /\*\*(\S(?:|.*?\S))\*\*$/;
 // matches: *some text*, but not **text* or * text *
 export const emphasisRegexAsterisk = /\*([^*\s]([^*])*[^*\s]|[^*\s])\*$/;
 // matches: __some text__, but not __ text __
-const strongRegexUnderscores = /__(\S(?:|.*?\S))__$/;
+const strongRegexUnderscores = /(?<!\S)__(\S(?:|.*?\S))__$/;
 // matches: _some text_, but not __text_ or _ text _
 const emphasisRegexUnderscore = /(?<!\S)_([^_\s]([^_])*[^_\s]|[^_\s])_$/;
 // matches: [ *any* thing ]( any thing )

--- a/test/rich-text/inputrules.test.ts
+++ b/test/rich-text/inputrules.test.ts
@@ -99,6 +99,7 @@ describe("mark input rules", () => {
         ["__not a match_", false],
         ["_ no-match_", false],
         ["_no-match _", false],
+        ["text_no-match_", false],
     ];
     // eslint-disable-next-line jest/expect-expect
     it.each(emphasisUnderlineTests)(

--- a/test/rich-text/inputrules.test.ts
+++ b/test/rich-text/inputrules.test.ts
@@ -124,6 +124,7 @@ describe("mark input rules", () => {
         ["__should match__", true],
         ["__ no-match__", false],
         ["__no-match __", false],
+        ["text__no-match__", false],
     ];
     // eslint-disable-next-line jest/expect-expect
     it.each(boldUnderlineTests)(


### PR DESCRIPTION
[STACKS-520](https://stackoverflow.atlassian.net/browse/STACKS-520)

This PR is fixing an issue where Underscore Emphasis Autoformatting was triggered incorrectly. 
See the how to test section for more context.

The solution is leveraging a negative lookahead operator to make sure the first underscore is NOT preceded by a non-whitespace character.

# How to test
- Open the editor instance in rich text mode
- Type manually (not copy pasting) `text_text_` (or `text__text__`)
- Observe auto formatting NOT kicking in and rewriting the above to text<em>text</em> (or text<strong>text</strong>)
