### PR TITLE
fix(controls): improve focus style to meet WCAG 2.2 AA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@lezer/highlight": "^1.2.0",
                 "@lezer/markdown": "^1.2.0",
-                "@stackoverflow/stacks": "^2.0.8",
                 "@stackoverflow/stacks-icons": "^6.0.0",
                 "@types/markdown-it": "13.0.7",
                 "markdown-it": "^13.0.2",
@@ -36,6 +35,7 @@
                 "@playwright/test": "^1.41.1",
                 "@stackoverflow/commitlint-config": "^1.0.0",
                 "@stackoverflow/prettier-config": "^1.0.0",
+                "@stackoverflow/stacks": "^2.1.0-rc.0",
                 "@stackoverflow/tsconfig": "^1.0.0",
                 "@types/jest": "^29.5.11",
                 "@typescript-eslint/eslint-plugin": "^6.19.1",
@@ -70,6 +70,7 @@
                 "webpack-merge": "^5.10.0"
             },
             "peerDependencies": {
+                "@stackoverflow/stacks": "^2.1.0",
                 "highlight.js": "^11.6.0"
             }
         },
@@ -1094,7 +1095,8 @@
         "node_modules/@hotwired/stimulus": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
-            "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
+            "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==",
+            "dev": true
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
@@ -1696,6 +1698,7 @@
             "version": "2.11.8",
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "dev": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -1768,9 +1771,10 @@
             }
         },
         "node_modules/@stackoverflow/stacks": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.0.9.tgz",
-            "integrity": "sha512-PnY/GiTcPTcWte9vlhOFmpBjf6+NhTwpY37BUj9ZwfW7gnIxoA9mM8K1ytXrYdoY/9St2b105b752vE85lygRg==",
+            "version": "2.1.0-rc.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.1.0-rc.0.tgz",
+            "integrity": "sha512-2486luRyDyKre3PhLUagXYKq/z0TRbtrc0J92Ehnwor7rWGDjUty2q0xvEmbXj0pNp2Lr+slrN5NvxWFY7Sifg==",
+            "dev": true,
             "dependencies": {
                 "@hotwired/stimulus": "^3.2.2",
                 "@popperjs/core": "^2.11.8"
@@ -13424,7 +13428,8 @@
         "@hotwired/stimulus": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
-            "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
+            "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==",
+            "dev": true
         },
         "@humanwhocodes/config-array": {
             "version": "0.11.14",
@@ -13908,7 +13913,8 @@
         "@popperjs/core": {
             "version": "2.11.8",
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "dev": true
         },
         "@sinclair/typebox": {
             "version": "0.27.8",
@@ -13971,9 +13977,10 @@
             "requires": {}
         },
         "@stackoverflow/stacks": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.0.9.tgz",
-            "integrity": "sha512-PnY/GiTcPTcWte9vlhOFmpBjf6+NhTwpY37BUj9ZwfW7gnIxoA9mM8K1ytXrYdoY/9St2b105b752vE85lygRg==",
+            "version": "2.1.0-rc.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.1.0-rc.0.tgz",
+            "integrity": "sha512-2486luRyDyKre3PhLUagXYKq/z0TRbtrc0J92Ehnwor7rWGDjUty2q0xvEmbXj0pNp2Lr+slrN5NvxWFY7Sifg==",
+            "dev": true,
             "requires": {
                 "@hotwired/stimulus": "^3.2.2",
                 "@popperjs/core": "^2.11.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
                 "webpack-merge": "^5.10.0"
             },
             "peerDependencies": {
-                "@stackoverflow/stacks": "^2.1.0",
+                "@stackoverflow/stacks": "~2.1.0",
                 "highlight.js": "^11.6.0"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "@playwright/test": "^1.41.1",
                 "@stackoverflow/commitlint-config": "^1.0.0",
                 "@stackoverflow/prettier-config": "^1.0.0",
-                "@stackoverflow/stacks": "^2.1.0-rc.0",
+                "@stackoverflow/stacks": "^2.1.0",
                 "@stackoverflow/tsconfig": "^1.0.0",
                 "@types/jest": "^29.5.11",
                 "@typescript-eslint/eslint-plugin": "^6.19.1",
@@ -1771,9 +1771,9 @@
             }
         },
         "node_modules/@stackoverflow/stacks": {
-            "version": "2.1.0-rc.0",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.1.0-rc.0.tgz",
-            "integrity": "sha512-2486luRyDyKre3PhLUagXYKq/z0TRbtrc0J92Ehnwor7rWGDjUty2q0xvEmbXj0pNp2Lr+slrN5NvxWFY7Sifg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.1.0.tgz",
+            "integrity": "sha512-NtFZvJTm2RLxQtTHV228+syuOjFw8Xps4EYgLTYV88PbE+BbKAfsWm1kCbvxFubvkQba/WRidDlXOuMwlSvmeQ==",
             "dev": true,
             "dependencies": {
                 "@hotwired/stimulus": "^3.2.2",
@@ -13977,9 +13977,9 @@
             "requires": {}
         },
         "@stackoverflow/stacks": {
-            "version": "2.1.0-rc.0",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.1.0-rc.0.tgz",
-            "integrity": "sha512-2486luRyDyKre3PhLUagXYKq/z0TRbtrc0J92Ehnwor7rWGDjUty2q0xvEmbXj0pNp2Lr+slrN5NvxWFY7Sifg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.1.0.tgz",
+            "integrity": "sha512-NtFZvJTm2RLxQtTHV228+syuOjFw8Xps4EYgLTYV88PbE+BbKAfsWm1kCbvxFubvkQba/WRidDlXOuMwlSvmeQ==",
             "dev": true,
             "requires": {
                 "@hotwired/stimulus": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "prosemirror-view": "^1.32.7"
     },
     "peerDependencies": {
-        "@stackoverflow/stacks": "^2.1.0",
+        "@stackoverflow/stacks": "~2.1.0",
         "highlight.js": "^11.6.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "@playwright/test": "^1.41.1",
         "@stackoverflow/commitlint-config": "^1.0.0",
         "@stackoverflow/prettier-config": "^1.0.0",
+        "@stackoverflow/stacks": "^2.1.0-rc.0",
         "@stackoverflow/tsconfig": "^1.0.0",
         "@types/jest": "^29.5.11",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
@@ -86,7 +87,6 @@
     "dependencies": {
         "@lezer/highlight": "^1.2.0",
         "@lezer/markdown": "^1.2.0",
-        "@stackoverflow/stacks": "^2.0.8",
         "@stackoverflow/stacks-icons": "^6.0.0",
         "@types/markdown-it": "13.0.7",
         "markdown-it": "^13.0.2",
@@ -106,6 +106,7 @@
         "prosemirror-view": "^1.32.7"
     },
     "peerDependencies": {
+        "@stackoverflow/stacks": "^2.1.0",
         "highlight.js": "^11.6.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@playwright/test": "^1.41.1",
         "@stackoverflow/commitlint-config": "^1.0.0",
         "@stackoverflow/prettier-config": "^1.0.0",
-        "@stackoverflow/stacks": "^2.1.0-rc.0",
+        "@stackoverflow/stacks": "^2.1.0",
         "@stackoverflow/tsconfig": "^1.0.0",
         "@types/jest": "^29.5.11",
         "@typescript-eslint/eslint-plugin": "^6.19.1",

--- a/src/shared/menu/helpers.ts
+++ b/src/shared/menu/helpers.ts
@@ -239,7 +239,7 @@ export function makeMenuButton(
     cssClasses?: string[]
 ): HTMLButtonElement {
     const button = document.createElement("button");
-    button.className = `s-editor-btn s-btn s-btn__muted js-editor-btn js-${key}`;
+    button.className = `s-editor-btn s-btn js-editor-btn js-${key}`;
 
     if (cssClasses) {
         button.classList.add(...cssClasses);

--- a/src/stacks-editor/editor.ts
+++ b/src/stacks-editor/editor.ts
@@ -351,13 +351,13 @@ export class StacksEditor implements View {
         const container = document.createElement("div");
         container.className = "flex--item d-flex ai-center ml24 fc-medium";
 
-        container.innerHTML = escapeHTML`<div class="s-btn-group s-btn-group--radio fw-nowrap">
+        container.innerHTML = escapeHTML`<div class="s-btn-group s-btn-group--radio fw-nowrap myn2">
     <input type="radio" name="mode-toggle-${this.internalId}"
         id="mode-toggle-rich-${this.internalId}"
         class="s-btn--radio js-editor-toggle-btn"
         data-mode="${EditorType.RichText}"
         ${richCheckedProp} />
-    <label class="s-btn s-btn__muted s-btn__outlined s-editor-btn px6"
+    <label class="s-btn s-btn__muted s-btn__outlined s-editor-btn"
         for="mode-toggle-rich-${this.internalId}"
         title="${_t("menubar.mode_toggle_richtext_title")}">
         <span class="svg-icon-bg iconRichText"></span>
@@ -371,7 +371,7 @@ export class StacksEditor implements View {
         data-mode="${EditorType.Commonmark}"
         data-preview="false"
         ${markCheckedProp} />
-    <label class="s-btn s-btn__muted s-btn__outlined s-editor-btn px6"
+    <label class="s-btn s-btn__muted s-btn__outlined s-editor-btn"
         for="mode-toggle-markdown-${this.internalId}"
         title="${_t("menubar.mode_toggle_markdown_title")}">
         <span class="svg-icon-bg iconMarkdown"></span>

--- a/src/styles/custom-components.css
+++ b/src/styles/custom-components.css
@@ -6,53 +6,6 @@
     }
 }
 
-/* TODO UPSTREAM */
-.s-btn-group__radio {
-    display: flex;
-}
-
-/* TODO altered from upstream .s-btn-group>.s-btn */
-.s-btn-group__radio .s-btn:not(:last-of-type) {
-    margin-right: -1px;
-}
-
-.s-btn-group__radio .s-btn:not(:first-of-type):not(:last-of-type) {
-    border-radius: 0;
-}
-
-.s-btn-group__radio .s-btn:first-of-type:not(:only-of-type) {
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0;
-}
-
-.s-btn-group__radio .s-btn:last-of-type:not(:only-of-type) {
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
-}
-
-.s-btn-group__radio input[type="checkbox"],
-.s-btn-group__radio input[type="radio"] {
-    display: none;
-}
-
-/* TODO extends .s-btn.is-selected and .s-btn-group>.s-btn.is-selected */
-:is(.s-btn-group__radio input[type="checkbox"]):checked + label.s-btn,
-:is(.s-btn-group__radio input[type="radio"]):checked + label.s-btn {
-    background: var(--theme-button-selected-background-color);
-    box-shadow: none;
-    color: var(--theme-button-selected-color);
-    z-index: var(--zi-selected);
-}
-
-:is(.s-btn-group__radio input[type="checkbox"]):focus + label.s-btn,
-:is(.s-btn-group__radio input[type="radio"]):focus + label.s-btn {
-    box-shadow: 0 0 0 var(--su-static4) var(--focus-ring);
-}
-
-.s-btn-group__radio .s-editor-btn {
-    --editor-button-border-color: currentColor;
-}
-
 .s-editor-shadow {
     transform-style: preserve-3d;
 }
@@ -98,17 +51,29 @@
 
 .s-btn.s-editor-btn {
     border-radius: var(--br-sm);
+    color: var(--black-500);
     padding: var(--su2);
 }
 
-.s-btn.s-editor-btn:hover:not(.s-btn-group .s-btn.s-editor-btn),
-.s-btn.s-editor-btn:focus:not(.s-btn-group .s-btn.s-editor-btn) {
-    background-color: var(--theme-secondary-200) !important;
+.s-btn.s-editor-btn:hover {
     color: var(--black-600) !important;
 }
 
-.s-btn.s-editor-btn:focus {
-    box-shadow: 0 0 0 var(--su-static4) var(--focus-ring);
+/*
+    NOTE: These focus-visible styles exist to override the Stacks styles for editor buttons.
+    Since the editor buttons require the focus rings to be applied outside of the button,
+    we need to override the Stacks styles, which place the rings within the button.
+*/
+.s-btn.s-editor-btn:not(.s-btn__link):not(.s-btn__unset):focus-visible {
+    border-color: transparent !important;
+    box-shadow: 0 0 0 var(--su-static2) var(--theme-secondary-400) !important;
+    color: var(--black-500) !important;
+    outline: var(--su-static2) solid transparent !important;
+}
+
+/* NOTE: Transparent focus background only applied when not hovered or in the selected state */
+.s-btn.s-editor-btn:not(.s-btn__link):not(.s-btn__unset):not(.is-selected):not(:hover):focus-visible {
+    background-color: transparent !important;
 }
 
 .s-btn.s-editor-btn.is-selected,
@@ -117,8 +82,7 @@
     color: var(--theme-secondary-600) !important;
 }
 
-.s-btn.s-editor-btn.is-selected:hover,
-.s-btn.s-editor-btn.is-selected:focus {
+.s-btn.s-editor-btn.is-selected:hover {
     color: var(--theme-secondary-500) !important;
 }
 
@@ -128,6 +92,11 @@
 
 .s-btn.s-editor-btn.s-btn__dropdown:after {
     right: var(--su2);
+}
+
+.s-btn-group--radio .s-btn.s-editor-btn {
+    margin: calc(var(--su2) * -1) 0;
+    padding: var(--su4) var(--su6);
 }
 
 .s-editor--dropdown-item {

--- a/src/styles/custom-components.css
+++ b/src/styles/custom-components.css
@@ -72,7 +72,9 @@
 }
 
 /* NOTE: Transparent focus background only applied when not hovered or in the selected state */
-.s-btn.s-editor-btn:not(.s-btn__link):not(.s-btn__unset):not(.is-selected):not(:hover):focus-visible {
+.s-btn.s-editor-btn:not(.s-btn__link):not(.s-btn__unset):not(.is-selected):not(
+        :hover
+    ):focus-visible {
     background-color: transparent !important;
 }
 


### PR DESCRIPTION
Closes [STACKS-542](https://stackoverflow.atlassian.net/browse/STACKS-542)

This PR updates focus styles for buttons that are editor controls.

> **Note**
> This PR removes styling for `.s-btn-group__radio`. This element no longer exists (it's now `.s-btn-group--radio`).

> ~**Note**~
> ~This output of this PR may look incorrect until the @StackExchange/stacks dependency is updated beyond `2.0.9`.~