### PR TITLE
fix(link-preview): ensure spinner is not shown indefinetely when no preview results are available

### DIFF
--- a/src/rich-text/plugins/link-preview.ts
+++ b/src/rich-text/plugins/link-preview.ts
@@ -150,7 +150,7 @@ function generateRecentPreviewDecorations(
         if (!n.isTextOnly && n.content) {
             // if the url is in the cache, insert the link preview
             linkPreviewDecorations.push(insertLinkPreview(n.pos, n.content));
-        } else if (!n.content) {
+        } else if (n.content === null) {
             // otherwise, add the loading styles
             // attach the node decorations to the text's parent node
             const resolved = doc.resolve(n.pos);


### PR DESCRIPTION
Jira: [TEAMS-12649](https://stackoverflow.atlassian.net/browse/TEAMS-12649)
Related Core PR: https://github.com/StackEng/StackOverflow/pull/19095
Release Candidate: https://www.npmjs.com/package/@stackoverflow/stacks-editor/v/0.10.4-rc.0
