### PR TITLE
build(deps-dev): bump @stackexchange/stacks from 2.2.0 to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "@playwright/test": "^1.41.2",
                 "@stackoverflow/commitlint-config": "^1.0.0",
                 "@stackoverflow/prettier-config": "^1.0.0",
-                "@stackoverflow/stacks": "^2.2.0",
+                "@stackoverflow/stacks": "^2.3.0",
                 "@stackoverflow/tsconfig": "^1.0.0",
                 "@types/jest": "^29.5.12",
                 "@typescript-eslint/eslint-plugin": "^7.0.2",
@@ -2623,9 +2623,9 @@
             }
         },
         "node_modules/@stackoverflow/stacks": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.2.0.tgz",
-            "integrity": "sha512-2sbDzO0XqD6Cw6Zy+J8rFG3+SM+SxsV3HwH2aUP4VbRftZpf4ZvswKNgd0MzDnnarGlmnf10KCZ92D29/WY08w==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.3.0.tgz",
+            "integrity": "sha512-yoMpyS6OneCMtRrs4urR/Aj+l/IkeLmNbC89EzO/7An6pe8Doj20wT99fgbnnAvC+IxO+aQTO5+gFnZ6LbzHGw==",
             "dev": true,
             "dependencies": {
                 "@hotwired/stimulus": "^3.2.2",
@@ -15746,9 +15746,9 @@
             "requires": {}
         },
         "@stackoverflow/stacks": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.2.0.tgz",
-            "integrity": "sha512-2sbDzO0XqD6Cw6Zy+J8rFG3+SM+SxsV3HwH2aUP4VbRftZpf4ZvswKNgd0MzDnnarGlmnf10KCZ92D29/WY08w==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.3.0.tgz",
+            "integrity": "sha512-yoMpyS6OneCMtRrs4urR/Aj+l/IkeLmNbC89EzO/7An6pe8Doj20wT99fgbnnAvC+IxO+aQTO5+gFnZ6LbzHGw==",
             "dev": true,
             "requires": {
                 "@hotwired/stimulus": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@playwright/test": "^1.41.2",
         "@stackoverflow/commitlint-config": "^1.0.0",
         "@stackoverflow/prettier-config": "^1.0.0",
-        "@stackoverflow/stacks": "^2.2.0",
+        "@stackoverflow/stacks": "^2.3.0",
         "@stackoverflow/tsconfig": "^1.0.0",
         "@types/jest": "^29.5.12",
         "@typescript-eslint/eslint-plugin": "^7.0.2",

--- a/src/stacks-editor/editor.ts
+++ b/src/stacks-editor/editor.ts
@@ -351,13 +351,13 @@ export class StacksEditor implements View {
         const container = document.createElement("div");
         container.className = "flex--item d-flex ai-center ml24 fc-medium";
 
-        container.innerHTML = escapeHTML`<div class="s-btn-group s-btn-group--radio fw-nowrap myn2">
+        container.innerHTML = escapeHTML`<div class="s-btn-group s-editor-btn-group fw-nowrap myn2">
     <input type="radio" name="mode-toggle-${this.internalId}"
         id="mode-toggle-rich-${this.internalId}"
         class="s-btn--radio js-editor-toggle-btn"
         data-mode="${EditorType.RichText}"
         ${richCheckedProp} />
-    <label class="s-btn s-btn__muted s-btn__outlined s-editor-btn"
+    <label class="s-btn s-btn__muted s-btn__icon px6 py2 s-editor-btn"
         for="mode-toggle-rich-${this.internalId}"
         title="${_t("menubar.mode_toggle_richtext_title")}">
         <span class="svg-icon-bg iconRichText"></span>
@@ -371,7 +371,7 @@ export class StacksEditor implements View {
         data-mode="${EditorType.Commonmark}"
         data-preview="false"
         ${markCheckedProp} />
-    <label class="s-btn s-btn__muted s-btn__outlined s-editor-btn"
+    <label class="s-btn s-btn__muted px6 py2 s-editor-btn"
         for="mode-toggle-markdown-${this.internalId}"
         title="${_t("menubar.mode_toggle_markdown_title")}">
         <span class="svg-icon-bg iconMarkdown"></span>
@@ -392,7 +392,7 @@ export class StacksEditor implements View {
     data-mode="${EditorType.Commonmark}"
     data-preview="${previewEnabled.toString()}"
     ${previewCheckedProp} />
-<label class="s-btn s-btn__muted s-btn__outlined s-editor-btn px6"
+<label class="s-btn s-btn__muted s-btn__icon px6 py2 s-editor-btn"
     for="mode-toggle-preview-${this.internalId}"
     title="${_t("menubar.mode_toggle_preview_title")}">
     <span class="svg-icon-bg iconMarkdownPreview"></span>

--- a/src/styles/custom-components.css
+++ b/src/styles/custom-components.css
@@ -96,11 +96,6 @@
     right: var(--su2);
 }
 
-.s-btn-group--radio .s-btn.s-editor-btn {
-    margin: calc(var(--su2) * -1) 0;
-    padding: var(--su4) var(--su6);
-}
-
 .s-editor--dropdown-item {
     padding: var(--su4) var(--su12);
 }


### PR DESCRIPTION
This PR updates Stacks Classic from 2.2.0 to 2.3.0 and makes updates to the markdown toggle to support the new button group styling.

@CGuindon when you have a sec, check out [the deploy preview](https://deploy-preview-293--stacks-editor.netlify.app/) and let me know if it looks ok to you. The button padding needed to be tweaked, so if you'd like the button padding tweaked further let me know.

Once this is approved, I'll cut a new stacks-editor release with this change and update our [Core PR for updating Stacks](https://github.com/StackEng/StackOverflow/pull/18992) with it, which will resolve the [button group issue mentioned there](https://github.com/StackEng/StackOverflow/pull/18992#pullrequestreview-1949611902).

![image](https://github.com/StackExchange/Stacks-Editor/assets/647177/312b9f80-d650-4902-a255-8d97675223da)
