### PR TITLE
fix(image-upload): increase text contrast for accepted files string to meet accessibility standards

### DIFF
--- a/src/shared/prosemirror-plugins/image-upload.ts
+++ b/src/shared/prosemirror-plugins/image-upload.ts
@@ -313,7 +313,7 @@ export class ImageUploader extends PluginInterfaceView<
 
     getCaptionElement(text: string): HTMLElement {
         const uploadCaptionEl = document.createElement("span");
-        uploadCaptionEl.className = "fc-light fs-caption";
+        uploadCaptionEl.className = "fc-black-500 fs-caption";
 
         let captionText = "(Max size 2 MiB)";
         if (text) {


### PR DESCRIPTION
**Describe your changes**

Updating the text contrast for the accepted file types string so that it meets accessibility standards for contrast.

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

**Additional context**

Matches a change in SO editor.