### PR TITLE
Tweak webpack css-loader config to fix build errors

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -29,14 +29,10 @@ module.exports = (_, argv) => {
                         {
                             loader: "css-loader",
                             options: {
-                                importLoaders: 2,
+                                importLoaders: 1,
                                 url: {
-                                    filter: (_, resourcePath) => {
-                                        // Disable url handling for @stackoverflow/stacks
-                                        return !resourcePath.includes(
-                                            "@stackoverflow/stacks"
-                                        );
-                                    },
+                                    // let our svg rule handle importing svg files everywhere
+                                    filter: (url) => url.endsWith(".svg"),
                                 },
                             },
                         },


### PR DESCRIPTION
**Describe your changes**

Updates the `css-loader` settings in Webpack to fix build errors on my machine. I'm not entirely sure why the existing fix isn't enough, but I've added a more concise fix with a comment that also describes what's happening. I also updated `importLoaders` to the correct value while I was in there.

Side note: I'm not entirely sure why the `filter` rule is even necessary, since one would _think_ that the `/\.svg$/i` rule above would kick in correctly and the pipeline would continue on without doing anything else, but it doesn't. 🤷

<details><summary>Partial error message</summary>

```plaintext
... (12 similar errors preceding)

ERROR in data:image/svg+xml;,%3csvg width=%27100%25%27 height=%27100%25%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3crect width=%27100%25%27 height=%27100%25%27 fill=%27none%27 rx=%275%27 ry=%275%27 stroke=%27%23000000%27 stroke-width=%278%27 stroke-dasharray=%277%2c 22%27 stroke-dashoffset=%270%27 stroke-linecap=%27square%27/%3e%3c/svg%3e
Module build failed: UnhandledSchemeError: Reading from "data:image/svg+xml;,%3csvg width=%27100%25%27 height=%27100%25%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3crect width=%27100%25%27 height=%27100%25%27 fill=%27none%27 rx=%275%27 ry=%275%27 stroke=%27%23000000%27 stroke-width=%278%27 stroke-dasharray=%277%2c 22%27 stroke-dashoffset=%270%27 stroke-linecap=%27square%27/%3e%3c/svg%3e" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "data:" URIs.
    at D:\code\Stacks-Editor\node_modules\webpack\lib\NormalModule.js:918:25
    at Hook.eval [as callAsync] (eval at create (D:\code\Stacks-Editor\node_modules\tapable\lib\HookCodeFactory.js:33:10), <anonymous>:16:1)
    at Object.processResource (D:\code\Stacks-Editor\node_modules\webpack\lib\NormalModule.js:915:8)
    at processResource (D:\code\Stacks-Editor\node_modules\loader-runner\lib\LoaderRunner.js:220:11)
    at iteratePitchingLoaders (D:\code\Stacks-Editor\node_modules\loader-runner\lib\LoaderRunner.js:171:10)
    at runLoaders (D:\code\Stacks-Editor\node_modules\loader-runner\lib\LoaderRunner.js:398:2)
    at NormalModule._doBuild (D:\code\Stacks-Editor\node_modules\webpack\lib\NormalModule.js:905:3)
    at NormalModule.build (D:\code\Stacks-Editor\node_modules\webpack\lib\NormalModule.js:1081:15)
    at D:\code\Stacks-Editor\node_modules\webpack\lib\Compilation.js:1400:12
    at NormalModule.needBuild (D:\code\Stacks-Editor\node_modules\webpack\lib\NormalModule.js:1407:32)
 @ ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[2].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[2].use[2]!./node_modules/@stackoverflow/stacks/dist/css/stacks.css 15:37-399
 @ ./site/site.css.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[2].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[2].use[2]!./site/site.css 4:0-246 14:26-59
 @ ./site/site.css
 @ ./site/index.ts 16:0-20

webpack 5.91.0 compiled with 13 errors in 5370 ms
```

</details>

**PR Checklist**

- [ ] N/A ~~All new/changed functionality includes unit and (optionally) e2e tests as appropriate~~
- [ ] N/A ~~All new/changed functions have `/** ... */` docs~~
- [x] I've added the `bug`/`enhancement` and other labels as appropriate
