### PR TITLE
refactor: Remove liquid templates

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -47,7 +47,7 @@ module.exports = (env, argv) => {
                         templateContent: new Function(
                             ["content"],
                             `return \`${htmlLayout}\`;`
-                        )(String(htmlView)),
+                        )(htmlView),
                         filename: f,
                     });
                 }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
                 "husky": "^9.0.11",
                 "jest": "^29.7.0",
                 "jest-environment-jsdom": "^29.7.0",
-                "liquidjs-loader": "^1.0.1",
                 "mini-css-extract-plugin": "^2.8.1",
                 "mini-svg-data-uri": "^1.4.4",
                 "postcss": "^8.4.38",
@@ -4078,15 +4077,6 @@
             "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
             "dev": true
         },
-        "node_modules/big.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6003,15 +5993,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
-        },
-        "node_modules/emojis-list": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4"
-            }
         },
         "node_modules/encodeurl": {
             "version": "1.0.2",
@@ -9011,33 +8992,6 @@
                 "uc.micro": "^1.0.1"
             }
         },
-        "node_modules/liquidjs": {
-            "version": "9.43.0",
-            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.43.0.tgz",
-            "integrity": "sha512-qZZuL5Emja2UgCqiLewiw9bvwZQwm19TTGFxDkonVzB4YSTOZ8tuTVo/7Uu/AeW1cL2Qb/at3DSoV8wwyFXQCw==",
-            "dev": true,
-            "bin": {
-                "liquid": "bin/liquid.js",
-                "liquidjs": "bin/liquid.js"
-            },
-            "engines": {
-                "node": ">=4.8.7"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/liquidjs"
-            }
-        },
-        "node_modules/liquidjs-loader": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/liquidjs-loader/-/liquidjs-loader-1.0.1.tgz",
-            "integrity": "sha512-5OmXG5Vphlv7Nvvzn5sZxnGLfFOvt5K6g54gfe52PeiBEUurxDEJqO1hOM+sKa/kivD1SbEs73klHJeiMgZRfA==",
-            "dev": true,
-            "dependencies": {
-                "liquidjs": "^9.16.1",
-                "loader-utils": "^2.0.0"
-            }
-        },
         "node_modules/load-json-file": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -9091,20 +9045,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6.11.5"
-            }
-        },
-        "node_modules/loader-utils": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
             }
         },
         "node_modules/locate-path": {
@@ -16741,12 +16681,6 @@
             "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
             "dev": true
         },
-        "big.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-            "dev": true
-        },
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -18180,12 +18114,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
-        },
-        "emojis-list": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
             "dev": true
         },
         "encodeurl": {
@@ -20381,22 +20309,6 @@
                 "uc.micro": "^1.0.1"
             }
         },
-        "liquidjs": {
-            "version": "9.43.0",
-            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.43.0.tgz",
-            "integrity": "sha512-qZZuL5Emja2UgCqiLewiw9bvwZQwm19TTGFxDkonVzB4YSTOZ8tuTVo/7Uu/AeW1cL2Qb/at3DSoV8wwyFXQCw==",
-            "dev": true
-        },
-        "liquidjs-loader": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/liquidjs-loader/-/liquidjs-loader-1.0.1.tgz",
-            "integrity": "sha512-5OmXG5Vphlv7Nvvzn5sZxnGLfFOvt5K6g54gfe52PeiBEUurxDEJqO1hOM+sKa/kivD1SbEs73klHJeiMgZRfA==",
-            "dev": true,
-            "requires": {
-                "liquidjs": "^9.16.1",
-                "loader-utils": "^2.0.0"
-            }
-        },
         "load-json-file": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -20438,17 +20350,6 @@
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
             "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
             "dev": true
-        },
-        "loader-utils": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "dev": true,
-            "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            }
         },
         "locate-path": {
             "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
         "husky": "^9.0.11",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "liquidjs-loader": "^1.0.1",
         "mini-css-extract-plugin": "^2.8.1",
         "mini-svg-data-uri": "^1.4.4",
         "postcss": "^8.4.38",

--- a/site/layout.html
+++ b/site/layout.html
@@ -127,11 +127,7 @@
             <label id="a11y-editor-label" class="v-visible-sr">
                 Stacks-Editor demo implementation
             </label>
-            {% block content %}
-            <h1 class="mt32">Minimum viable example</h1>
-            <textarea id="content" name="content" class="d-none"></textarea>
-            <div id="example-1"></div>
-            {% endblock %}
+            ${content}
         </main>
     </body>
 </html>

--- a/site/views/dualeditor.html
+++ b/site/views/dualeditor.html
@@ -1,4 +1,3 @@
-{% layout "layout.html" %} {% block content %}
 <label id="a11y-editor-label-2" class="v-visible-sr">
     Stacks-Editor second demo implementation
 </label>
@@ -8,4 +7,3 @@
     <div id="example-1" class="mb8 js-tables-enabled"></div>
     <div id="example-2" class="js-tables-enabled"></div>
 </div>
-{% endblock %}

--- a/site/views/empty.html
+++ b/site/views/empty.html
@@ -1,5 +1,3 @@
-{% layout "layout.html" %} {% block content %}
 <textarea id="content" name="content" class="d-none"></textarea>
 <h1 class="mt32">Empty starter page</h1>
 <div id="example-1" class="js-tables-enabled"></div>
-{% endblock %}

--- a/site/views/index.html
+++ b/site/views/index.html
@@ -1,4 +1,3 @@
-{% layout "layout.html" %} {% block content %}
 <textarea id="content" class="d-none">
 # Here’s a thought
 
@@ -116,4 +115,3 @@ Don't forget tables:
 <h1>Stacks Editor</h1>
 <h3>Showcasing our new editing experience for Stack Overflow</h3>
 <div id="example-1"></div>
-{% endblock %}

--- a/site/views/md-preview.html
+++ b/site/views/md-preview.html
@@ -1,4 +1,3 @@
-{% layout "layout.html" %} {% block content %}
 <textarea id="content" name="content" class="d-none">
 # Here’s a thought
 
@@ -115,4 +114,3 @@ Don't forget tables:
 </textarea>
 <h1 class="mt32">Markdown Preview Enabled</h1>
 <div id="example-1" class="js-md-preview-enabled"></div>
-{% endblock %}

--- a/site/views/noimage.html
+++ b/site/views/noimage.html
@@ -1,5 +1,3 @@
-{% layout "layout.html" %} {% block content %}
 <textarea id="content" name="content" class="d-none"></textarea>
 <h1 class="mt32">this text area should populate without an image button</h1>
 <div id="example-1" class="js-images-disabled"></div>
-{% endblock %}

--- a/site/views/plugins.html
+++ b/site/views/plugins.html
@@ -1,4 +1,3 @@
-{% layout "layout.html" %} {% block content %}
 <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 
 <textarea id="content" class="d-none">
@@ -31,4 +30,3 @@ There's also a very silly plugin set in the 🤘 menu. Try it out!
 
 <h1>Plugin Playground</h1>
 <div id="example-1" class="js-plugins-enabled"></div>
-{% endblock %}


### PR DESCRIPTION
I noticed when working on #352 that the Liquid decency is outdated and flagged in a security issue. This PR refactors the preview site templates to use a simpler approach as we're not using any of the features Liquid provides.