### PR TITLE
fix(code-blocks): remove buggy "exit code block" functionality

### DIFF
--- a/src/rich-text/commands/index.ts
+++ b/src/rich-text/commands/index.ts
@@ -532,7 +532,7 @@ export function exitInclusiveMarkCommand(
     dispatch: (tr: Transaction) => void
 ) {
     const $cursor = (<TextSelection>state.selection).$cursor;
-    const marks = state.storedMarks || $cursor.marks();
+    const marks = state.storedMarks || $cursor?.marks();
 
     if (!marks?.length) {
         return false;
@@ -546,7 +546,7 @@ export function exitInclusiveMarkCommand(
     }
 
     // check if we're at the end of the exitable mark
-    const nextNode = $cursor.nodeAfter;
+    const nextNode = $cursor?.nodeAfter;
     let endExitables: Mark[];
 
     let tr = state.tr;

--- a/src/rich-text/key-bindings.ts
+++ b/src/rich-text/key-bindings.ts
@@ -2,7 +2,6 @@ import {
     toggleMark,
     wrapIn,
     setBlockType,
-    exitCode,
     baseKeymap,
 } from "prosemirror-commands";
 import { redo, undo } from "prosemirror-history";
@@ -26,7 +25,6 @@ import {
     moveToPreviousCellCommand,
     moveSelectionAfterTableCommand,
     insertRichTextTableCommand,
-    exitInclusiveMarkCommand,
     indentCodeBlockLinesCommand,
     unindentCodeBlockLinesCommand,
     toggleHeadingLevel,
@@ -86,9 +84,6 @@ export function allKeymaps(
         "Mod-,": toggleMark(schema.marks.sub),
         "Mod-.": toggleMark(schema.marks.sup),
         "Mod-'": toggleMark(schema.marks.kbd),
-        // users expect to be able to leave certain blocks/marks using the arrow keys
-        "ArrowRight": exitInclusiveMarkCommand,
-        "ArrowDown": exitCode,
     });
 
     const keymaps = [

--- a/src/rich-text/key-bindings.ts
+++ b/src/rich-text/key-bindings.ts
@@ -30,6 +30,7 @@ import {
     toggleHeadingLevel,
     toggleTagLinkCommand,
     toggleList,
+    exitInclusiveMarkCommand,
 } from "./commands";
 
 export function allKeymaps(
@@ -84,6 +85,8 @@ export function allKeymaps(
         "Mod-,": toggleMark(schema.marks.sub),
         "Mod-.": toggleMark(schema.marks.sup),
         "Mod-'": toggleMark(schema.marks.kbd),
+        // exit inline code block using the right arrow key
+        "ArrowRight": exitInclusiveMarkCommand,
     });
 
     const keymaps = [

--- a/test/rich-text/commands/index.test.ts
+++ b/test/rich-text/commands/index.test.ts
@@ -785,12 +785,20 @@ describe("commands", () => {
         );
 
         it("should handle the case when $cursor is null", () => {
+            // suppress console.warn
+            const consoleWarnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
+
             let state = createState("this is my state", []);
             state = state.apply(
                 state.tr.setSelection(TextSelection.create(state.doc, 0, null))
             );
             expect((<TextSelection>state.selection).$cursor).toBeNull();
             expect(() => exitInclusiveMarkCommand(state, null)).not.toThrow();
+
+            // restore console.warn
+            consoleWarnSpy.mockRestore();
         });
     });
 

--- a/test/rich-text/commands/index.test.ts
+++ b/test/rich-text/commands/index.test.ts
@@ -1,4 +1,4 @@
-import { EditorState, Transaction } from "prosemirror-state";
+import { EditorState, TextSelection, Transaction } from "prosemirror-state";
 import {
     exitInclusiveMarkCommand,
     insertRichTextHorizontalRuleCommand,
@@ -733,7 +733,7 @@ describe("commands", () => {
         );
     });
 
-    describe("exitMarkCommand", () => {
+    describe("exitInclusiveMarkCommand", () => {
         it("all exitable marks should also be inclusive: true", () => {
             Object.keys(testRichTextSchema.marks).forEach((markName) => {
                 const mark = testRichTextSchema.marks[markName];
@@ -781,6 +781,14 @@ describe("commands", () => {
 
                 state = applySelection(state, from);
                 expect(exitInclusiveMarkCommand(state, null)).toBe(true);
+            }
+        );
+
+        it("should handle the case when $cursor is null", () => {
+                let state = createState("this is my state", []);
+                state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 0, null))); 
+                expect((<TextSelection>state.selection).$cursor).toBeNull();
+                expect(() => exitInclusiveMarkCommand(state, null)).not.toThrow();
             }
         );
     });

--- a/test/rich-text/commands/index.test.ts
+++ b/test/rich-text/commands/index.test.ts
@@ -785,12 +785,13 @@ describe("commands", () => {
         );
 
         it("should handle the case when $cursor is null", () => {
-                let state = createState("this is my state", []);
-                state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 0, null))); 
-                expect((<TextSelection>state.selection).$cursor).toBeNull();
-                expect(() => exitInclusiveMarkCommand(state, null)).not.toThrow();
-            }
-        );
+            let state = createState("this is my state", []);
+            state = state.apply(
+                state.tr.setSelection(TextSelection.create(state.doc, 0, null))
+            );
+            expect((<TextSelection>state.selection).$cursor).toBeNull();
+            expect(() => exitInclusiveMarkCommand(state, null)).not.toThrow();
+        });
     });
 
     describe("indentCodeBlockLinesCommand", () => {


### PR DESCRIPTION
Closes #191

**Describe your changes**

This PR removes the custom logic that was attached to "arrow right" and "arrow down" keypresses.

These were added in #64 in an attempt to add some behaviour where people could exit code blocks by pressing arrow keys. Unfortunately that introduces bugs like this one, where you can't use the arrow keys to navigate _inside_ a code block any more - instead you get teleported out of it. Annoying!

After removing this code, things seem to work as I would expect them to anyway.

https://github.com/user-attachments/assets/a3186241-4d82-4353-8a30-cd4439462207

**PR Checklist**

- [ ] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [ ] All new/changed functions have `/** ... */` docs
- [ ] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

Tested on Chrome and Safari.

**Additional context**

n/a
