### PR TITLE
fix(preview): Fix constant layout shift as preview rerenders

### DIFF
--- a/site/index.ts
+++ b/site/index.ts
@@ -121,12 +121,6 @@ const ImageUploadHandler: ImageUploadOptions["handler"] = (file) =>
  * NOTE: synchronous renderers can simply return Promise.resolve()
  */
 const examplePreviewRenderer: PreviewRenderer = async (content, container) => {
-    const spinner = document.createElement("span");
-    spinner.className = "is-loading";
-    spinner.textContent =
-        "Intentionally delaying render for example purposes...";
-    container.appendChild(spinner);
-
     // add a fake load delay (because we can)
     await sleepAsync(500);
 

--- a/site/index.ts
+++ b/site/index.ts
@@ -120,29 +120,15 @@ const ImageUploadHandler: ImageUploadOptions["handler"] = (file) =>
  * Sample preview renderer that has a fake delay and uses the default Markdown-It renderer
  * NOTE: synchronous renderers can simply return Promise.resolve()
  */
-const examplePreviewRenderer: PreviewRenderer = async (content, container, abortSignal) => {
+const examplePreviewRenderer: PreviewRenderer = async (content, container) => {
     const spinner = document.createElement("span");
     spinner.className = "is-loading";
     spinner.textContent =
         "Intentionally delaying render for example purposes...";
     container.appendChild(spinner);
 
-    const interruptableSleepAsync = (delayMs: number, signal: AbortSignal) => new Promise<void>((resolve, reject) => {
-        const timeoutId = setTimeout(() => {
-            resolve();
-        }, delayMs);
-
-        signal.addEventListener("abort", () => {
-            clearTimeout(timeoutId);
-            reject(new Error('aborted'));
-        });
-    });
-
-    await interruptableSleepAsync(500, abortSignal)
-        .catch(() => {
-            container.removeChild(spinner);
-        })
-
+    // add a fake load delay (because we can)
+    await sleepAsync(500);
 
     const instance = MarkdownIt("commonmark", {
         html: false,

--- a/site/index.ts
+++ b/site/index.ts
@@ -120,15 +120,29 @@ const ImageUploadHandler: ImageUploadOptions["handler"] = (file) =>
  * Sample preview renderer that has a fake delay and uses the default Markdown-It renderer
  * NOTE: synchronous renderers can simply return Promise.resolve()
  */
-const examplePreviewRenderer: PreviewRenderer = async (content, container) => {
+const examplePreviewRenderer: PreviewRenderer = async (content, container, abortSignal) => {
     const spinner = document.createElement("span");
     spinner.className = "is-loading";
     spinner.textContent =
         "Intentionally delaying render for example purposes...";
     container.appendChild(spinner);
 
-    // add a fake load delay (because we can)
-    await sleepAsync(500);
+    const interruptableSleepAsync = (delayMs: number, signal: AbortSignal) => new Promise<void>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+            resolve();
+        }, delayMs);
+
+        signal.addEventListener("abort", () => {
+            clearTimeout(timeoutId);
+            reject(new Error('aborted'));
+        });
+    });
+
+    await interruptableSleepAsync(500, abortSignal)
+        .catch(() => {
+            container.removeChild(spinner);
+        })
+
 
     const instance = MarkdownIt("commonmark", {
         html: false,

--- a/src/commonmark/editor.ts
+++ b/src/commonmark/editor.ts
@@ -38,7 +38,8 @@ import { createMenuEntries } from "../shared/menu";
  */
 export type PreviewRenderer = (
     content: string,
-    container: HTMLElement
+    container: HTMLElement,
+    abortSignal?: AbortSignal
 ) => Promise<void>;
 
 export interface CommonmarkOptions extends CommonViewOptions {

--- a/src/commonmark/editor.ts
+++ b/src/commonmark/editor.ts
@@ -38,8 +38,7 @@ import { createMenuEntries } from "../shared/menu";
  */
 export type PreviewRenderer = (
     content: string,
-    container: HTMLElement,
-    abortSignal?: AbortSignal
+    container: HTMLElement
 ) => Promise<void>;
 
 export interface CommonmarkOptions extends CommonViewOptions {

--- a/src/commonmark/plugins/preview.ts
+++ b/src/commonmark/plugins/preview.ts
@@ -26,7 +26,6 @@ class PreviewView implements PluginView {
     private renderer: PreviewRenderer;
     private renderTimeoutId: number | null = null;
     private renderDelayMs: number;
-    private abortController: AbortController;
 
     private isShown: boolean;
 
@@ -102,23 +101,13 @@ class PreviewView implements PluginView {
         if (this.isShown) {
             this.container.appendChild(this.dom);
 
-            if (this.abortController) {
-                this.abortController.abort();
-            }
-
-            // Create a new AbortController for the current render
-            this.abortController = new AbortController();
-            const signal = this.abortController.signal;
-
-            void this.renderer?.(text, this.dom, signal).catch((e: Error) => {
-                if (e.name !== 'AbortError') {
-                    error(
-                        "PreviewView.updatePreview",
-                        `Uncaught exception in preview renderer`,
-                        e
-                    );
-                }
-            });
+            void this.renderer?.(text, this.dom).catch((e) =>
+                error(
+                    "PreviewView.updatePreview",
+                    `Uncaught exception in preview renderer`,
+                    e
+                )
+            );
         }
     }
 }

--- a/src/commonmark/plugins/preview.ts
+++ b/src/commonmark/plugins/preview.ts
@@ -99,8 +99,6 @@ class PreviewView implements PluginView {
 
         // if showing the preview, fire off the renderer async
         if (this.isShown) {
-            // always clear the preview before re-rendering
-            this.dom.innerHTML = "";
             this.container.appendChild(this.dom);
 
             void this.renderer?.(text, this.dom).catch((e) =>


### PR DESCRIPTION
**Describe your changes**

Fixes the issue described in [this meta post](https://meta.stackoverflow.com/questions/431137/stacks-editor-is-doing-rapid-layout-shift-as-i-edit-the-body-input). As the user types, preview container content is removed before the promise is resolved, causing the page layout to shift during the time it takes for the promise to resolve. The fix is to not clear the preview, rather wait for the content to be replaced when the promise is resolved. 

**Before**

[screen-capture (1).webm](https://github.com/user-attachments/assets/de33cf85-6be9-4d0b-a58a-3d389dfef417)



**After**

[screen-capture.webm](https://github.com/user-attachments/assets/74cc0864-59f8-4dfe-8a92-935b14587d78)



**PR Checklist**

- [ ] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [ ] All new/changed functions have `/** ... */` docs
- [ ] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: [e.g. desktop, iPhone6, etc.]
- OS: [e.g. iOS]
- Browser [e.g. chrome, safari]
- Version [e.g. 22]

**Additional context**

Add any other context about the PR here.
