### PR TITLE
fix(markdown): Fix code block selection off by one error

### DIFF
--- a/src/commonmark/commands.ts
+++ b/src/commonmark/commands.ts
@@ -439,8 +439,8 @@ function blockWrapIn(
     to += 1;
 
    //always insert a newline after the selection
-        tr = tr.insertText(surroundingChar, to, to);
-        to += 1;
+    tr = tr.insertText(surroundingChar, to, to);
+    to += 1;
    
     // insert the code fences from the end first so we don't mess up our from index
     //consider if we need to add the surrounding char too, if the text is not already surrounded by newline
@@ -453,7 +453,6 @@ function blockWrapIn(
 
     // set the selection to the text inside the code fences, skipping the leading newline
     if (dispatch) {
-
         tr.setSelection(
             TextSelection.create(
                 state.apply(tr).doc,

--- a/src/commonmark/commands.ts
+++ b/src/commonmark/commands.ts
@@ -445,12 +445,19 @@ function blockWrapIn(
     // insert the code fences from the end first so we don't mess up our from index
     //consider if we need to add the surrounding char too, if the text is not already surrounded by newline
 
-    const preceedingNewlineNeeded = from > 0 && state.doc.textBetween(from - 1, from) !== surroundingChar ? surroundingChar : '';
-    const followingNewlineNeeded = to + 1 < state.doc.content.size && state.doc.textBetween(to, to + 1) !== surroundingChar ? surroundingChar : '';
+    const preceedingNewlineNeeded =
+        from > 0 && state.doc.textBetween(from - 1, from) !== surroundingChar
+            ? surroundingChar
+            : "";
+    const followingNewlineNeeded =
+        to + 1 < state.doc.content.size &&
+        state.doc.textBetween(to, to + 1) !== surroundingChar
+            ? surroundingChar
+            : "";
 
     tr.insertText(formattingText + followingNewlineNeeded, to);
     tr.insertText(preceedingNewlineNeeded + formattingText, from);
-    to += (formattingText.length * 2) + preceedingNewlineNeeded.length;
+    to += formattingText.length * 2 + preceedingNewlineNeeded.length;
 
     // set the selection to the text inside the code fences, skipping the leading newline
 

--- a/src/commonmark/commands.ts
+++ b/src/commonmark/commands.ts
@@ -416,57 +416,49 @@ function blockWrapIn(
         const newlineOffset = 2; // account for  two inserted newlines
         return insertRawText(
             insertedBlock,
-            formattingText.length + newlineOffset,
+            formattingText.length + newlineOffset, //only selects the placeholder text, not the formattingText
             formattingText.length + placeholderText.length + newlineOffset,
             state,
             dispatch
         );
     }
 
-    let { from, to } = state.selection;
+    const from = state.selection.from;
+    let to = state.selection.to;
 
-    // check if we need to unwrap
-    if (blockUnwrapIn(formattingText, state, dispatch)) {
-        return true;
-    }
 
     // wrap the selected block in code fences, prepending/appending newlines if necessary
+
+
     let tr = state.tr;
 
-    // if the character immediately preceding the selection isn't a newline, add one
-    if (from > 0 && state.doc.textBetween(from - 1, from) !== "\n") {
-        tr = tr.insertText("\n", from, from);
-        from += 1;
-        to += 1;
-    }
-
-    // if the character immediately postceding the selection isn't a newline, add one
-    if (
-        to + 1 < state.doc.content.size &&
-        state.doc.textBetween(to, to + 1) !== "\n"
-    ) {
-        tr = tr.insertText("\n", to + 1, to + 1);
-        to += 1;
-    }
-
-    // add this char before and after the selection along with the formatting text
     const surroundingChar = "\n";
 
-    // insert the code fences from the end first so we don't mess up our from index
-    tr.insertText(surroundingChar + formattingText, to);
-    tr.insertText(formattingText + surroundingChar, from);
+    //always insert a newline before the selection
+    tr = tr.insertText(surroundingChar, from, from);
+    to += 1;
 
+   //always insert a newline after the selection
+        tr = tr.insertText(surroundingChar, to, to);
+        to += 1;
+   
+    // insert the code fences from the end first so we don't mess up our from index
+    //consider if we need to add the surrounding char too, if the text is not already surrounded by newline
+
+    const preceedingNewlineNeeded = from > 0 && state.doc.textBetween(from - 1, from) !== surroundingChar ? surroundingChar : '';
+    const followingNewlineNeeded = to + 1 < state.doc.content.size && state.doc.textBetween(to, to + 1) !== surroundingChar ? surroundingChar : '';
+    tr.insertText(formattingText + followingNewlineNeeded, to);
+    tr.insertText(preceedingNewlineNeeded + formattingText, from);
+    to += (formattingText.length * 2) + preceedingNewlineNeeded.length;
+
+    // set the selection to the text inside the code fences, skipping the leading newline
     if (dispatch) {
-        // adjust our new text selection based on how many characters we added
-        const addedTextModifier =
-            surroundingChar.length + formattingText.length;
 
         tr.setSelection(
             TextSelection.create(
                 state.apply(tr).doc,
-                from,
-                // add modifier twice, once for added leading text, once for added trailing text
-                to + addedTextModifier * 2
+                from + preceedingNewlineNeeded.length,
+                to
             )
         );
 

--- a/src/commonmark/commands.ts
+++ b/src/commonmark/commands.ts
@@ -423,6 +423,8 @@ function blockWrapIn(
         );
     }
 
+    if (!dispatch) return true;
+
     const from = state.selection.from;
     let to = state.selection.to;
 
@@ -436,10 +438,10 @@ function blockWrapIn(
     tr = tr.insertText(surroundingChar, from, from);
     to += 1;
 
-   //always insert a newline after the selection
+    //always insert a newline after the selection
     tr = tr.insertText(surroundingChar, to, to);
     to += 1;
-   
+
     // insert the code fences from the end first so we don't mess up our from index
     //consider if we need to add the surrounding char too, if the text is not already surrounded by newline
 
@@ -451,19 +453,18 @@ function blockWrapIn(
     to += (formattingText.length * 2) + preceedingNewlineNeeded.length;
 
     // set the selection to the text inside the code fences, skipping the leading newline
-    if (dispatch) {
-        tr.setSelection(
-            TextSelection.create(
-                state.apply(tr).doc,
-                from + preceedingNewlineNeeded.length,
-                to
-            )
-        );
 
-        tr.scrollIntoView();
+    tr.setSelection(
+        TextSelection.create(
+            state.apply(tr).doc,
+            from + preceedingNewlineNeeded.length,
+            to
+        )
+    );
 
-        dispatch(tr);
-    }
+    tr.scrollIntoView();
+
+    dispatch(tr);
 
     return true;
 }

--- a/src/commonmark/commands.ts
+++ b/src/commonmark/commands.ts
@@ -426,9 +426,7 @@ function blockWrapIn(
     const from = state.selection.from;
     let to = state.selection.to;
 
-
     // wrap the selected block in code fences, prepending/appending newlines if necessary
-
 
     let tr = state.tr;
 
@@ -447,6 +445,7 @@ function blockWrapIn(
 
     const preceedingNewlineNeeded = from > 0 && state.doc.textBetween(from - 1, from) !== surroundingChar ? surroundingChar : '';
     const followingNewlineNeeded = to + 1 < state.doc.content.size && state.doc.textBetween(to, to + 1) !== surroundingChar ? surroundingChar : '';
+
     tr.insertText(formattingText + followingNewlineNeeded, to);
     tr.insertText(preceedingNewlineNeeded + formattingText, from);
     to += (formattingText.length * 2) + preceedingNewlineNeeded.length;

--- a/test/commonmark/commands.test.ts
+++ b/test/commonmark/commands.test.ts
@@ -220,6 +220,22 @@ some text
             );
         });
 
+        it("should wrap partial selection in block characters", () => {
+            const content = "some text";
+            const expectedSelection = `\`\`\`
+some
+\`\`\``;
+            const expectedContent = "\n" + expectedSelection + "\n" + " text";
+
+            const state = createState(content, 0, 4);
+
+            expect(state).transactionSuccess(
+                commands.blockWrapInCommand("```"),
+                expectedContent,
+                expectedSelection
+            );
+        });
+
         it("should unwrap block", () => {
             const content = `\`\`\`
 some text


### PR DESCRIPTION
**Describe your changes**

Fixes the issue described in [this meta post](https://meta.stackoverflow.com/questions/431670/creating-a-code-block-in-staging-ground-includes-one-additional-character-after). In markdown mode, the code block button surrounds one character extra than the user's selection. This PR corrects that, cleans up the code, and adds comments to make it more understandable. 

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Browser [e.g. chrome, safari]