### PR TITLE
fix(inline-code): disallow "inline code" when selection has linebreaks

### DIFF
--- a/src/shared/menu/entries.ts
+++ b/src/shared/menu/entries.ts
@@ -41,6 +41,7 @@ import {
     insertRichTextTableCommand,
     toggleList,
     toggleCodeBlock,
+    toggleInlineCode,
 } from "../../rich-text/commands";
 import { _t } from "../localization";
 import { makeMenuButton, makeMenuDropdown } from "./helpers";
@@ -330,7 +331,7 @@ export const createMenuEntries = (
             {
                 key: "toggleCode",
                 richText: {
-                    command: toggleMark(schema.marks.code),
+                    command: toggleInlineCode,
                     active: markActive(schema.marks.code),
                 },
                 commonmark: inlineCodeCommand,

--- a/test/rich-text/commands/code-block.test.ts
+++ b/test/rich-text/commands/code-block.test.ts
@@ -681,7 +681,7 @@ describe("toggleInlineCode command", () => {
         expect(selectedText).toBe("Line1\nLine2");
 
         // Capture the document before applying the command.
-        const prevJSON = state.doc.toJSON();
+        const prevJSON = state.doc.toJSON() as unknown;
 
         // Apply the toggleInlineCode command.
         state = applyCommand(toggleInlineCode, state);
@@ -718,7 +718,7 @@ describe("toggleInlineCode command", () => {
         const selectedText = state.doc.textBetween(from, to, "\n", "\n");
         expect(selectedText).toContain("\n");
 
-        const prevJSON = state.doc.toJSON();
+        const prevJSON = state.doc.toJSON() as unknown;
 
         // Apply the command.
         state = applyCommand(toggleInlineCode, state);

--- a/test/rich-text/test-helpers.ts
+++ b/test/rich-text/test-helpers.ts
@@ -266,8 +266,9 @@ export function rangeHasMark(
 }
 
 /** Extend prosemirror-schema-basic to add softbreak (to represent linebreaks coming from pasted Markdown) */
-const extendedNodes = (basicSchema.spec.nodes as OrderedMap<any>)
-    .addToEnd("softbreak", {
+const extendedNodes = (basicSchema.spec.nodes as OrderedMap<any>).addToEnd(
+    "softbreak",
+    {
         inline: true,
         group: "inline",
         selectable: false,
@@ -275,7 +276,8 @@ const extendedNodes = (basicSchema.spec.nodes as OrderedMap<any>)
             return ["br"];
         },
         parseDOM: [{ tag: "br" }],
-    });
+    }
+);
 
 const extendedMarks = basicSchema.spec.marks;
 

--- a/test/rich-text/test-helpers.ts
+++ b/test/rich-text/test-helpers.ts
@@ -1,4 +1,4 @@
-import { DOMParser, Node, Schema, Slice } from "prosemirror-model";
+import { DOMParser, MarkType, Node, Schema, Slice } from "prosemirror-model";
 import { schema as basicSchema } from "prosemirror-schema-basic";
 import {
     EditorState,
@@ -10,7 +10,6 @@ import {
 import { EditorView } from "prosemirror-view";
 import { richTextSchemaSpec } from "../../src/rich-text/schema";
 import { MenuCommand } from "../../src/shared/menu";
-import OrderedMap from "orderedmap";
 
 /** Consistent schema to test against */
 export const testRichTextSchema = new Schema(richTextSchemaSpec);
@@ -252,7 +251,7 @@ export function rangeHasMark(
     state: EditorState,
     from: number,
     to: number,
-    markType: any
+    markType: MarkType
 ): boolean {
     let hasMark = false;
     state.doc.nodesBetween(from, to, (node) => {
@@ -266,18 +265,15 @@ export function rangeHasMark(
 }
 
 /** Extend prosemirror-schema-basic to add softbreak (to represent linebreaks coming from pasted Markdown) */
-const extendedNodes = (basicSchema.spec.nodes as OrderedMap<any>).addToEnd(
-    "softbreak",
-    {
-        inline: true,
-        group: "inline",
-        selectable: false,
-        toDOM() {
-            return ["br"];
-        },
-        parseDOM: [{ tag: "br" }],
-    }
-);
+const extendedNodes = basicSchema.spec.nodes.addToEnd("softbreak", {
+    inline: true,
+    group: "inline",
+    selectable: false,
+    toDOM() {
+        return ["br"];
+    },
+    parseDOM: [{ tag: "br" }],
+});
 
 const extendedMarks = basicSchema.spec.marks;
 

--- a/test/rich-text/test-helpers.ts
+++ b/test/rich-text/test-helpers.ts
@@ -1,4 +1,5 @@
 import { DOMParser, Node, Schema, Slice } from "prosemirror-model";
+import { schema as basicSchema } from "prosemirror-schema-basic";
 import {
     EditorState,
     NodeSelection,
@@ -9,6 +10,7 @@ import {
 import { EditorView } from "prosemirror-view";
 import { richTextSchemaSpec } from "../../src/rich-text/schema";
 import { MenuCommand } from "../../src/shared/menu";
+import OrderedMap from "orderedmap";
 
 /** Consistent schema to test against */
 export const testRichTextSchema = new Schema(richTextSchemaSpec);
@@ -244,3 +246,40 @@ export function executeTransaction(
 
     return { newState, isValid };
 }
+
+/** Returns whether the selection range has a mark of the given type */
+export function rangeHasMark(
+    state: EditorState,
+    from: number,
+    to: number,
+    markType: any
+): boolean {
+    let hasMark = false;
+    state.doc.nodesBetween(from, to, (node) => {
+        if (node.marks && node.marks.some((mark) => mark.type === markType)) {
+            hasMark = true;
+            return false;
+        }
+        return true;
+    });
+    return hasMark;
+}
+
+/** Extend prosemirror-schema-basic to add softbreak (to represent linebreaks coming from pasted Markdown) */
+const extendedNodes = (basicSchema.spec.nodes as OrderedMap<any>)
+    .addToEnd("softbreak", {
+        inline: true,
+        group: "inline",
+        selectable: false,
+        toDOM() {
+            return ["br"];
+        },
+        parseDOM: [{ tag: "br" }],
+    });
+
+const extendedMarks = basicSchema.spec.marks;
+
+export const schemaWithSoftbreak = new Schema({
+    nodes: extendedNodes,
+    marks: extendedMarks,
+});


### PR DESCRIPTION
**Describe your changes**

This PR addresses an issue raised on Meta here: https://meta.stackoverflow.com/questions/430988/what-causes-single-backticks-on-every-line-of-code

To address this, we disable the "inline code" button when the text selection includes linebreaks. Users should use code blocks instead of inline code when there are multiple lines.

The fix applies whether there are "real" linebreaks in the selection, or if there are "soft breaks" - these are what you get when you paste code into the Markdown view, then switch back to the rich text mode.

To test this, paste in the example code block from the Meta post:

```
from modules.prompt import create_conversation_prompt
from langchain.chains import ConversationChain
from langchain_core.output_parsers import StrOutputParser
from langchain_core.runnables import RunnablePassthrough
```

Note - this is _not_ currently detected as a code block by the rich text editor. So that makes it a good test for this.

Previously you would be able to toggle "inline text" on this, and get a bunch of paragraphs with backticks around each one. Now, the "inline code" button is disabled. Use the "code block" button to make it a proper code block instead.
