### PR TITLE
fix(code-blocks): add empty paragraph at end when using three backticks to create code block

### DIFF
--- a/src/rich-text/inputrules.ts
+++ b/src/rich-text/inputrules.ts
@@ -87,7 +87,7 @@ function markInputRule(
 }
 
 // Extend the InputRule type so that we can access its handler property.
-interface ExtendedInputRule extends InputRule {
+export interface ExtendedInputRule extends InputRule {
     handler: (
         state: EditorState,
         match: RegExpExecArray,

--- a/test/rich-text/inputrules.test.ts
+++ b/test/rich-text/inputrules.test.ts
@@ -1,6 +1,11 @@
-import { MarkType } from "prosemirror-model";
+import { MarkType, Node as PMNode } from "prosemirror-model";
 import { EditorView } from "prosemirror-view";
-import { richTextInputRules } from "../../src/rich-text/inputrules";
+import { schema as basicSchema } from "prosemirror-schema-basic";
+import {
+    ExtendedInputRule,
+    richTextInputRules,
+    textblockTypeTrailingParagraphInputRule,
+} from "../../src/rich-text/inputrules";
 import { stackOverflowValidateLink } from "../../src/shared/utils";
 import {
     applySelection,
@@ -11,6 +16,7 @@ import {
     sleepAsync,
     testRichTextSchema,
 } from "./test-helpers";
+import { EditorState } from "prosemirror-state";
 
 function dispatchInputAsync(view: EditorView, inputStr: string) {
     // insert all but the last character
@@ -205,4 +211,80 @@ describe("mark input rules", () => {
             });
         }
     );
+});
+
+describe("textblockTypeTrailingParagraphInputRule", () => {
+    it("inserts trailing paragraph when node is at the document end", () => {
+        // Create a doc with a single paragraph that contains only the trigger text "```".
+        const paragraph = basicSchema.nodes.paragraph.create(
+            null,
+            basicSchema.text("```")
+        );
+        const doc = basicSchema.nodes.doc.create(null, paragraph);
+        const state = EditorState.create({ doc, schema: basicSchema });
+
+        // Create the input rule that transforms the trigger text into a code_block and,
+        // if needed, appends an empty paragraph.
+        const rule = textblockTypeTrailingParagraphInputRule(
+            /^```$/,
+            basicSchema.nodes.code_block
+        ) as ExtendedInputRule;
+
+        // Simulate a match for the trigger text "```".
+        // In a paragraph, text typically starts at position 1. For a 3-character string, we use positions 1 to 4.
+        const match = /^```$/.exec("```")!;
+        const tr = rule.handler(state, match, 1, 4);
+        if (!tr) {
+            throw new Error("Expected a valid transaction");
+        }
+        const newDoc: PMNode = tr.doc;
+
+        // We expect the resulting doc to have two children:
+        //  - The first is the code_block that replaced the original trigger text.
+        //  - The second is the extra empty paragraph inserted at the end.
+        expect(newDoc.childCount).toBe(2);
+        expect(newDoc.child(0).type.name).toBe("code_block");
+        expect(newDoc.child(1).type.name).toBe("paragraph");
+        expect(newDoc.child(1).textContent).toBe("");
+    });
+
+    it("does not insert trailing paragraph when node is not at document end", () => {
+        // Create a doc with two paragraphs:
+        //  - The first contains the trigger text "```".
+        //  - The second contains additional text.
+        const paragraph1 = basicSchema.nodes.paragraph.create(
+            null,
+            basicSchema.text("```")
+        );
+        const paragraph2 = basicSchema.nodes.paragraph.create(
+            null,
+            basicSchema.text("Hello")
+        );
+        const doc = basicSchema.nodes.doc.create(null, [
+            paragraph1,
+            paragraph2,
+        ]);
+        const state = EditorState.create({ doc, schema: basicSchema });
+
+        const rule = textblockTypeTrailingParagraphInputRule(
+            /^```$/,
+            basicSchema.nodes.code_block
+        ) as ExtendedInputRule;
+        const match = /^```$/.exec("```")!;
+        const tr = rule.handler(state, match, 1, 4);
+        if (!tr) {
+            throw new Error("Expected a valid transaction");
+        }
+        const newDoc: PMNode = tr.doc;
+
+        // Since there's additional content after the transformed node,
+        // no extra paragraph should be appended.
+        // The document should have:
+        //  - The first child: the code_block replacing the trigger text.
+        //  - The second child: the unchanged paragraph with text "Hello".
+        expect(newDoc.childCount).toBe(2);
+        expect(newDoc.child(0).type.name).toBe("code_block");
+        expect(newDoc.child(1).type.name).toBe("paragraph");
+        expect(newDoc.child(1).textContent).toBe("Hello");
+    });
 });


### PR DESCRIPTION
This PR fixes one of the issues reported on Meta: https://meta.stackexchange.com/questions/407446/new-stacks-editors-code-block-usage-issues

Existing functionality: When pressing the Code Block button in the toolbar, a code block is created, and a new empty paragraph is created underneath, if we're at the end of the document. That means you can press the Down arrow to exit the code block.

The problem: This didn't work when creating a code block by entering three backticks: ```

The fix: Call the same `insertParagraphIfAtDocEnd` function when creating a code block using back ticks. This requires wrapping the `textblockTypeInputRule`.

https://github.com/user-attachments/assets/502e68ac-2534-4ebf-b41d-24a2b3ec313b

