### PR TITLE
fix(tooltips): tooltips always go below buttons

### DIFF
--- a/src/shared/menu/helpers.ts
+++ b/src/shared/menu/helpers.ts
@@ -127,7 +127,7 @@ export function makeMenuLinkEntry(
     dom.title = title;
     dom.setAttribute("aria-label", title);
     dom.dataset.controller = "s-tooltip";
-    dom.dataset.sTooltipPlacement = "top";
+    dom.dataset.sTooltipPlacement = "bottom";
 
     // create the svg svg-icon-bg element
     const icon = document.createElement("span");
@@ -260,7 +260,7 @@ export function makeMenuButton(
     button.title = title;
     button.setAttribute("aria-label", title);
     button.dataset.controller = "s-tooltip";
-    button.dataset.sTooltipPlacement = "top";
+    button.dataset.sTooltipPlacement = "bottom";
     button.dataset.key = key;
     button.type = "button";
 


### PR DESCRIPTION
This PR is a fix for the issue described here: https://meta.stackexchange.com/questions/407427/stacks-editor-toolbar-popup-not-visible-when-expending-upwards

Previously, the default for tooltips was set as `top`, but in practice they usually didn't do that, because there's not actually enough space _above_ the toolbar to display the tooltip. They normally display below the toolbar. The exception was when the window was short (or scrolled to the bottom). Without enough space below the toolbar either, the tooltips _did_ display above the toolbar, but then they hit an issue because the `overflow` CSS means that they weren't actually visible.

So, the fix here is simply to make them _always_ display below the toolbar. If that's below the line of the screen, that's at least better than rendering them in some place they can never be seen. You'd need to scroll down to actually use the editor anyway.