### PR TITLE
fix(rich-text-editor) interpret 4 spaces as a code block

### DIFF
--- a/src/rich-text/inputrules.ts
+++ b/src/rich-text/inputrules.ts
@@ -162,8 +162,13 @@ export const richTextInputRules = (
         (match) => ({ level: match[1].length })
     );
 
-    const codeBlockRule = textblockTypeTrailingParagraphInputRule(
+    const codeBlockBackticksRule = textblockTypeTrailingParagraphInputRule(
         /^```$/,
+        schema.nodes.code_block
+    );
+
+    const codeBlockSpacesRule = textblockTypeTrailingParagraphInputRule(
+        /^\s{4}$/,
         schema.nodes.code_block
     );
 
@@ -217,7 +222,8 @@ export const richTextInputRules = (
             blockquoteInputRule,
             spoilerInputRule,
             headingInputRule,
-            codeBlockRule,
+            codeBlockBackticksRule,
+            codeBlockSpacesRule,
             unorderedListRule,
             orderedListRule,
             inlineCodeRule,


### PR DESCRIPTION
**Describe your changes**

When using the rich text editor, we expect typed commonmark standards to be replaced with their visual equivalents.  This PR implements that for the commonmark standard of 4 spaces = code block. 

**PR Checklist**

- [ ] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [ ] All new/changed functions have `/** ... */` docs
- [ ] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: desktop
- Browser: Chrome

**Additional context**

Reported on [meta](https://meta.stackexchange.com/questions/407251/when-typing-code-backslashes-are-automatically-inserted)
