### PR TITLE
fix(link-editor): link editor glitchiness tweaks

### DIFF
--- a/src/rich-text/plugins/link-editor.ts
+++ b/src/rich-text/plugins/link-editor.ts
@@ -522,12 +522,16 @@ class LinkTooltip {
 
         let endIndex = $pos.indexAfter();
         let endPos = startPos + start.node.nodeSize;
-        while (
-            endIndex < $pos.parent.childCount &&
-            link.isInSet($pos.parent.child(endIndex).marks)
-        ) {
-            endPos += $pos.parent.child(endIndex).nodeSize;
-            endIndex += 1;
+        
+        // Don't double-count the length of the the node if we're at the start of it
+        if (endIndex !== $pos.index()) {
+            while (
+                endIndex < $pos.parent.childCount &&
+                link.isInSet($pos.parent.child(endIndex).marks)
+            ) {
+                endPos += $pos.parent.child(endIndex).nodeSize;
+                endIndex += 1;
+            }
         }
 
         return { from: startPos, to: endPos };

--- a/src/rich-text/plugins/link-editor.ts
+++ b/src/rich-text/plugins/link-editor.ts
@@ -413,13 +413,28 @@ class LinkTooltip {
         if (!marks.length) {
             return DecorationSet.empty;
         }
-
+    
+        // Use the linkAround helper to determine the full range of the link mark.
+        const linkRange = this.linkAround(newState);
+        if (!linkRange) {
+            return DecorationSet.empty;
+        }
+    
+        // Only show the tooltip if the selection is entirely within the link.
+        // If the selection starts before the link or ends after the link, do not show the tooltip.
+        if (newState.selection.from < linkRange.from || newState.selection.to > linkRange.to) {
+            return DecorationSet.empty;
+        }
+    
         // always update the state, regardless of document changes (potential metadata changes can change tooltip visuals)
         this.update(newState);
-
+    
+        // Compute the midpoint of the link's range to anchor the tooltip.
+        const pos = Math.floor((linkRange.from + linkRange.to) / 2);
+    
         // create the widget tooltip via EditorView callback
         const decoration = Decoration.widget(
-            newState.selection.from,
+            pos,
             (view) => {
                 /* NOTE: This function runs on every transaction update */
                 this.updateEventListeners(view);

--- a/src/rich-text/plugins/link-editor.ts
+++ b/src/rich-text/plugins/link-editor.ts
@@ -580,9 +580,7 @@ class LinkTooltip {
 
         this.editListener = () => {
             let tr = view.state.tr;
-            if (view.state.selection.empty) {
-                tr = this.expandSelection(view.state, view.state.tr);
-            }
+            tr = this.expandSelection(view.state, view.state.tr);
 
             const state = view.state.apply(tr);
             const { from, to } = state.selection;

--- a/src/rich-text/plugins/link-editor.ts
+++ b/src/rich-text/plugins/link-editor.ts
@@ -277,7 +277,7 @@ class LinkEditorPluginKey extends ManagedInterfaceKey<LinkEditorPluginState> {
 }
 
 /** The plugin key the image uploader plugin is tied to */
-const LINK_EDITOR_KEY = new LinkEditorPluginKey();
+export const LINK_EDITOR_KEY = new LinkEditorPluginKey();
 
 /** Manages the decorations necessary for drawing the link editor tooltip */
 class LinkTooltip {
@@ -413,25 +413,28 @@ class LinkTooltip {
         if (!marks.length) {
             return DecorationSet.empty;
         }
-    
+
         // Use the linkAround helper to determine the full range of the link mark.
         const linkRange = this.linkAround(newState);
         if (!linkRange) {
             return DecorationSet.empty;
         }
-    
+
         // Only show the tooltip if the selection is entirely within the link.
         // If the selection starts before the link or ends after the link, do not show the tooltip.
-        if (newState.selection.from < linkRange.from || newState.selection.to > linkRange.to) {
+        if (
+            newState.selection.from < linkRange.from ||
+            newState.selection.to > linkRange.to
+        ) {
             return DecorationSet.empty;
         }
-    
+
         // always update the state, regardless of document changes (potential metadata changes can change tooltip visuals)
         this.update(newState);
-    
+
         // Compute the midpoint of the link's range to anchor the tooltip.
         const pos = Math.floor((linkRange.from + linkRange.to) / 2);
-    
+
         // create the widget tooltip via EditorView callback
         const decoration = Decoration.widget(
             pos,
@@ -495,7 +498,7 @@ class LinkTooltip {
      * Gets the positions immediately before and after a link mark in the current selection
      * @param state
      */
-    private linkAround(state: EditorState) {
+    public linkAround(state: EditorState) {
         const $pos = state.selection.$from;
         const start = $pos.parent.childAfter($pos.parentOffset);
         if (!start.node) {
@@ -522,7 +525,7 @@ class LinkTooltip {
 
         let endIndex = $pos.indexAfter();
         let endPos = startPos + start.node.nodeSize;
-        
+
         // Don't double-count the length of the the node if we're at the start of it
         if (endIndex !== $pos.index()) {
             while (

--- a/src/rich-text/plugins/link-editor.ts
+++ b/src/rich-text/plugins/link-editor.ts
@@ -310,7 +310,7 @@ class LinkTooltip {
             <div class="s-popover--arrow"></div>
             <div class="d-flex ai-center">
                 <a href="${this.href}"
-                    class="wmx3 flex--item fs-body1 fw-normal truncate ml8 mr4"
+                    class="wmx3 flex--item fs-body1 fw-normal truncate ml8 mr4 us-none"
                     target="_blank"
                     rel="nofollow noreferrer">${this.href}</a>
                 <button type="button"

--- a/src/styles/custom-components.css
+++ b/src/styles/custom-components.css
@@ -209,7 +209,7 @@
 }
 
 /* Our editor often wraps things in their own divs. These wrappers should have the proper spacing below them */
-.ProseMirror.s-prose div {
+.ProseMirror.s-prose div:not(.s-popover--arrow) {
     margin-bottom: var(--s-prose-spacing);
 }
 

--- a/test/rich-text/plugins/link-editor.test.ts
+++ b/test/rich-text/plugins/link-editor.test.ts
@@ -582,13 +582,12 @@ describe("link-editor", () => {
 
             // Case 1: Selection extends outside the link.
             // For example, selecting from the very start of the paragraph (position 0).
-            const stateWithExtra = applySelection(state, 0);
+            const stateWithExtra = applySelection(state, 0, 8);
             let decos = getDecorations(stateWithExtra);
             expect(decos).toEqual(DecorationSet.empty);
 
             // Case 2: Selection fully within the link.
-            // Assume the link starts at position 7 (this depends on your document's positions).
-            const stateWithin = applySelection(state, 7);
+            const stateWithin = applySelection(state, 7, 8);
             decos = getDecorations(stateWithin);
             expect(decos).not.toEqual(DecorationSet.empty);
         });
@@ -606,16 +605,16 @@ describe("link-editor", () => {
             let state = createState(html, [
                 linkEditorPlugin({ validateLink: () => true }),
             ]);
+
             // Choose a selection that lies within the link.
-            // (Assume the link text "abcdef" is entirely within the link.)
             state = applySelection(state, 8);
             const tooltip = LINK_EDITOR_KEY.getState(state).linkTooltip;
             const linkRange = tooltip.linkAround(state);
             expect(linkRange).toBeDefined();
             const expectedMid = Math.floor((linkRange.from + linkRange.to) / 2);
 
-            const decos = getDecorations(state);
             // Look for the widget decoration (which should be the tooltip).
+            const decos = getDecorations(state);
             const widgetDeco = decos.find().find((deco) => {
                 if (!isWidgetDecoration(deco)) {
                     return false;
@@ -634,11 +633,13 @@ describe("link-editor", () => {
             let state = createState(html, [
                 linkEditorPlugin({ validateLink: () => true }),
             ]);
-            // Position the selection within the link text (assume "link" is 4 characters long).
+
+            // Position the selection within the link text.
             state = applySelection(state, 7);
             const tooltip = LINK_EDITOR_KEY.getState(state).linkTooltip;
             const range = tooltip.linkAround(state);
             expect(range).toBeDefined();
+
             // The computed visible length should equal the length of "link" (i.e. 4).
             expect(range.to - range.from).toBe(4);
         });

--- a/test/rich-text/plugins/link-editor.test.ts
+++ b/test/rich-text/plugins/link-editor.test.ts
@@ -1,8 +1,9 @@
 import { EditorState, Transaction } from "prosemirror-state";
-import { DecorationSet, EditorView } from "prosemirror-view";
+import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { RichTextEditor } from "../../../src/rich-text/editor";
 import {
     hideLinkEditor,
+    LINK_EDITOR_KEY,
     LinkEditor,
     linkEditorPlugin,
     showLinkEditor,
@@ -571,6 +572,75 @@ describe("link-editor", () => {
                 .dispatchEvent(new Event("mousedown"));
 
             return promise.then(() => cleanupPasteSupport());
+        });
+
+        it("only shows the tooltip when the selection is entirely within the link", () => {
+            const html = `<p>Hello <a href="https://www.example.com">link</a> world</p>`;
+            const state = createState(html, [
+                linkEditorPlugin({ validateLink: () => true }),
+            ]);
+
+            // Case 1: Selection extends outside the link.
+            // For example, selecting from the very start of the paragraph (position 0).
+            const stateWithExtra = applySelection(state, 0);
+            let decos = getDecorations(stateWithExtra);
+            expect(decos).toEqual(DecorationSet.empty);
+
+            // Case 2: Selection fully within the link.
+            // Assume the link starts at position 7 (this depends on your document's positions).
+            const stateWithin = applySelection(state, 7);
+            decos = getDecorations(stateWithin);
+            expect(decos).not.toEqual(DecorationSet.empty);
+        });
+
+        function isWidgetDecoration(
+            deco: Decoration
+        ): deco is Decoration & { spec: { stopEvent: () => boolean } } {
+            // Assign deco.spec to a local variable with an explicit type so that we can safely access stopEvent.
+            const spec = deco.spec as { stopEvent?: unknown };
+            return typeof spec.stopEvent === "function";
+        }
+
+        it("places the tooltip at the midpoint of the link", () => {
+            const html = `<p>Test <a href="https://www.example.com">abcdef</a></p>`;
+            let state = createState(html, [
+                linkEditorPlugin({ validateLink: () => true }),
+            ]);
+            // Choose a selection that lies within the link.
+            // (Assume the link text "abcdef" is entirely within the link.)
+            state = applySelection(state, 8);
+            const tooltip = LINK_EDITOR_KEY.getState(state).linkTooltip;
+            const linkRange = tooltip.linkAround(state);
+            expect(linkRange).toBeDefined();
+            const expectedMid = Math.floor((linkRange.from + linkRange.to) / 2);
+
+            const decos = getDecorations(state);
+            // Look for the widget decoration (which should be the tooltip).
+            const widgetDeco = decos.find().find((deco) => {
+                if (!isWidgetDecoration(deco)) {
+                    return false;
+                }
+                // Explicitly cast deco.spec so that stopEvent is typed.
+                const spec = deco.spec as { stopEvent: () => boolean };
+                return spec.stopEvent() === true;
+            });
+
+            expect(widgetDeco).toBeTruthy();
+            expect(widgetDeco.from).toBe(expectedMid);
+        });
+
+        it("calculates the correct link length (no double counting of tokens)", () => {
+            const html = `<p>Hello <a href="https://www.example.com">link</a></p>`;
+            let state = createState(html, [
+                linkEditorPlugin({ validateLink: () => true }),
+            ]);
+            // Position the selection within the link text (assume "link" is 4 characters long).
+            state = applySelection(state, 7);
+            const tooltip = LINK_EDITOR_KEY.getState(state).linkTooltip;
+            const range = tooltip.linkAround(state);
+            expect(range).toBeDefined();
+            // The computed visible length should equal the length of "link" (i.e. 4).
+            expect(range.to - range.from).toBe(4);
         });
     });
 


### PR DESCRIPTION
This PR addresses various glitches with the link editor, as reported [on Meta](https://meta.stackexchange.com/questions/407489/hypertext-link-url-editing-seems-broken-or-at-least-difficult-to-use-in-rich-tex) and also in #170 and #200.

Here's an example showing the glitches when editing the post that is referred to in the Meta post above. The specific Markdown can be [found here](https://stackoverflow.com/revisions/7d43428c-6a5e-40ca-87b9-5b6473c2a313/view-source).

https://github.com/user-attachments/assets/f5263342-e4b7-4906-89a2-ea26f6d18522

Changes:

- **Link selection**. Previously, the link editor popup would display if any of the selected text contained a link. The popup would display details of only the first link in the selection. If you selected a huge block of text that happened to contain a link, you'd see the link popup for the first one. The new behaviour is to only show the link popup if the selection _is a link_ or is _entirely contained within a link_.
- **Popup placement**. Previously the popup would anchor to your selection. Now, the popup is always anchored to the middle of the link itself. This means it doesn't move, and always appears in the same place.
- **No partial link editing**. Previously, if you selected only _some_ of a link's text and edited the URL, you'd end up with multiple links. Now, the whole link is edited.
- **Popover arrow was incorrect near the end of the document**. The popover arrow didn't show correctly if the popover appeared above the link, as it does at the end of the document.

Here's how the editor works on the same post now:

https://github.com/user-attachments/assets/43ed6f77-570f-45db-a8c0-5ae4d0127c78
