### PR TITLE
feat: add passthrough max file size param to image uploader 

### DIFF
--- a/src/shared/localization.ts
+++ b/src/shared/localization.ts
@@ -82,8 +82,11 @@ export const defaultStrings = {
     image_upload: {
         default_image_alt_text: "enter image description here" as string,
         external_url_validation_error: "The entered URL is invalid." as string,
-        upload_error_file_too_big:
-            "Your image is too large to upload (over 2 MiB)" as string,
+        upload_error_file_too_big: ({
+            sizeLimitMib,
+        }: {
+            sizeLimitMib: string;
+        }) => `Your image is too large to upload (over ${sizeLimitMib} MiB)`,
         upload_error_generic:
             "Image upload failed. Please try again." as string,
         upload_error_unsupported_format: ({


### PR DESCRIPTION
**Describe your changes**

[Jira](https://stackoverflow.atlassian.net/browse/DISCOCD-54)
[Meta](https://meta.stackexchange.com/questions/402075/the-stacks-editor-still-enforces-a-2-mib-image-size-limit-and-doesnt-support-t)
Allow passing through a param to control the file size limit of the image uploader. Default will remain 2 MiB. 

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: desktop
- Browser: chrome

**Additional context**

Add any other context about the PR here.
