### PR TITLE
refactor(code-blocks): make code block language code clearer

### DIFF
--- a/src/rich-text/editor.ts
+++ b/src/rich-text/editor.ts
@@ -47,7 +47,6 @@ import { createMenuPlugin } from "../shared/menu/plugin";
 export interface RichTextOptions extends CommonViewOptions {
     /** Array of LinkPreviewProviders to handle specific link preview urls */
     linkPreviewProviders?: LinkPreviewProvider[];
-    codeblockOverrideLanguage?: string;
 }
 
 /*
@@ -123,9 +122,7 @@ export class RichTextEditor extends BaseView {
                             this.options.parserFeatures
                         ),
                         linkPreviewPlugin(this.options.linkPreviewProviders),
-                        CodeBlockHighlightPlugin(
-                            this.options.codeblockOverrideLanguage
-                        ),
+                        CodeBlockHighlightPlugin(),
                         interfaceManagerPlugin(
                             this.options.pluginParentContainer
                         ),
@@ -185,7 +182,6 @@ export class RichTextEditor extends BaseView {
             parserFeatures: defaultParserFeatures,
             editorHelpLink: null,
             linkPreviewProviders: [],
-            codeblockOverrideLanguage: null,
             menuParentContainer: null,
             imageUpload: {
                 handler: defaultImageUploadHandler,

--- a/src/rich-text/node-views/code-block.ts
+++ b/src/rich-text/node-views/code-block.ts
@@ -11,7 +11,7 @@ export class CodeBlockView implements NodeView {
     dom: HTMLElement | null;
     contentDOM?: HTMLElement | null;
 
-    private language: string = null;
+    private currentLanguage: string = null;
 
     constructor(node: ProsemirrorNode) {
         this.dom = document.createElement("div");
@@ -27,8 +27,12 @@ export class CodeBlockView implements NodeView {
             return false;
         }
 
-        const rawLanguage = this.getLanguageFromBlock(node);
-        this.updateCodeBlock(rawLanguage);
+        const newLanguage = this.getLanguageFromBlock(node);
+        if (newLanguage !== this.currentLanguage) {
+            this.currentLanguage = newLanguage;
+            this.dom.querySelector(".js-language-indicator").textContent =
+                newLanguage;
+        }
 
         return true;
     }
@@ -55,14 +59,5 @@ export class CodeBlockView implements NodeView {
         }
 
         return null;
-    }
-
-    /** Updates the edit/code view */
-    private updateCodeBlock(rawLanguage: string) {
-        if (this.language !== rawLanguage) {
-            this.dom.querySelector(".js-language-indicator").textContent =
-                rawLanguage;
-            this.language = rawLanguage;
-        }
     }
 }

--- a/src/rich-text/node-views/code-block.ts
+++ b/src/rich-text/node-views/code-block.ts
@@ -28,6 +28,8 @@ export class CodeBlockView implements NodeView {
         }
 
         const newLanguage = this.getLanguageFromBlock(node);
+
+        // If the language has changed, update the language indicator
         if (newLanguage !== this.currentLanguage) {
             this.currentLanguage = newLanguage;
             this.dom.querySelector(".js-language-indicator").textContent =

--- a/src/rich-text/node-views/code-block.ts
+++ b/src/rich-text/node-views/code-block.ts
@@ -43,7 +43,7 @@ export class CodeBlockView implements NodeView {
 
     /** Gets the codeblock language from the node */
     private getLanguageFromBlock(node: ProsemirrorNode) {
-        let autodetectedLanguage = node.attrs.language as string;
+        let autodetectedLanguage = node.attrs.autodetectedLanguage as string;
 
         if (autodetectedLanguage) {
             autodetectedLanguage = _t("nodes.codeblock_lang_auto", {

--- a/src/rich-text/node-views/code-block.ts
+++ b/src/rich-text/node-views/code-block.ts
@@ -43,15 +43,18 @@ export class CodeBlockView implements NodeView {
 
     /** Gets the codeblock language from the node */
     private getLanguageFromBlock(node: ProsemirrorNode) {
+        const specifiedLanguage = getBlockLanguage(node);
+        if (specifiedLanguage) return specifiedLanguage;
+
         let autodetectedLanguage = node.attrs.autodetectedLanguage as string;
 
         if (autodetectedLanguage) {
-            autodetectedLanguage = _t("nodes.codeblock_lang_auto", {
+            return _t("nodes.codeblock_lang_auto", {
                 lang: autodetectedLanguage,
             });
         }
 
-        return autodetectedLanguage || getBlockLanguage(node);
+        return null;
     }
 
     /** Updates the edit/code view */

--- a/src/rich-text/node-views/code-block.ts
+++ b/src/rich-text/node-views/code-block.ts
@@ -11,7 +11,7 @@ export class CodeBlockView implements NodeView {
     dom: HTMLElement | null;
     contentDOM?: HTMLElement | null;
 
-    private currentLanguage: string = null;
+    private currentLanguageDisplayName: string = null;
 
     constructor(node: ProsemirrorNode) {
         this.dom = document.createElement("div");
@@ -27,13 +27,13 @@ export class CodeBlockView implements NodeView {
             return false;
         }
 
-        const newLanguage = this.getLanguageFromBlock(node);
+        const newLanguageDisplayName = this.getLanguageDisplayName(node);
 
         // If the language has changed, update the language indicator
-        if (newLanguage !== this.currentLanguage) {
-            this.currentLanguage = newLanguage;
+        if (newLanguageDisplayName !== this.currentLanguageDisplayName) {
+            this.currentLanguageDisplayName = newLanguageDisplayName;
             this.dom.querySelector(".js-language-indicator").textContent =
-                newLanguage;
+                newLanguageDisplayName;
         }
 
         return true;
@@ -48,18 +48,17 @@ export class CodeBlockView implements NodeView {
     }
 
     /** Gets the codeblock language from the node */
-    private getLanguageFromBlock(node: ProsemirrorNode) {
-        const specifiedLanguage = getBlockLanguage(node);
-        if (specifiedLanguage) return specifiedLanguage;
+    private getLanguageDisplayName(node: ProsemirrorNode) {
+        const language = getBlockLanguage(node);
 
-        let autodetectedLanguage = node.attrs.autodetectedLanguage as string;
-
-        if (autodetectedLanguage) {
-            return _t("nodes.codeblock_lang_auto", {
-                lang: autodetectedLanguage,
-            });
+        // for a user-specified language, just return the language name
+        if (!language.IsAutoDetected) {
+            return language.Language;
         }
 
-        return null;
+        // if the language was auto-detected, return it with "(auto)" appended
+        return _t("nodes.codeblock_lang_auto", {
+            lang: language.Language,
+        });
     }
 }

--- a/src/rich-text/schema.ts
+++ b/src/rich-text/schema.ts
@@ -92,7 +92,7 @@ const nodes: {
         marks: "",
         attrs: {
             params: { default: "" },
-            language: { default: "" },
+            autodetectedLanguage: { default: "" },
             isEditingProcessor: { default: false },
         },
         parseDOM: [

--- a/src/shared/highlighting/highlight-plugin.ts
+++ b/src/shared/highlighting/highlight-plugin.ts
@@ -106,13 +106,11 @@ export function getBlockLanguage(
 /**
  * Plugin that highlights all code within all code_blocks in the parent
  */
-export function CodeBlockHighlightPlugin(
-    defaultFallbackLanguage: string
-): Plugin {
+export function CodeBlockHighlightPlugin(): Plugin {
     const extractor = (block: ProsemirrorNode) => {
         const detectedLanguage = block.attrs.language as string;
         return (
-            detectedLanguage || getBlockLanguage(block, defaultFallbackLanguage)
+            detectedLanguage || getBlockLanguage(block, null)
         );
     };
 

--- a/src/shared/highlighting/highlight-plugin.ts
+++ b/src/shared/highlighting/highlight-plugin.ts
@@ -88,15 +88,12 @@ function dealiasLanguage(rawLanguage: string): Language {
  * Gets the language string from a code_block node
  * @param block The block to get the language string from
  */
-export function getBlockLanguage(
-    block: ProsemirrorNode
-): string {
+export function getBlockLanguage(block: ProsemirrorNode): string {
     // commonmark spec suggests that the "first word" in a fence's info string is the language
     // https://spec.commonmark.org/0.29/#info-string
     // https://spec.commonmark.org/0.29/#example-112
     const rawInfoString = (block.attrs.params as string) || "";
-    const rawLanguage =
-        rawInfoString.split(/\s/)[0].toLowerCase() || null;
+    const rawLanguage = rawInfoString.split(/\s/)[0].toLowerCase() || null;
 
     // attempt to dealias the language before sending out to the highlighter
     return dealiasLanguage(rawLanguage);

--- a/src/shared/highlighting/highlight-plugin.ts
+++ b/src/shared/highlighting/highlight-plugin.ts
@@ -85,10 +85,10 @@ function dealiasLanguage(rawLanguage: string): Language {
 }
 
 /**
- * Gets the language string from a code_block node
+ * Gets the language string from a code_block node, if one was specified
  * @param block The block to get the language string from
  */
-export function getBlockLanguage(block: ProsemirrorNode): string {
+function getSpecifiedBlockLanguage(block: ProsemirrorNode): string {
     // commonmark spec suggests that the "first word" in a fence's info string is the language
     // https://spec.commonmark.org/0.29/#info-string
     // https://spec.commonmark.org/0.29/#example-112
@@ -100,17 +100,31 @@ export function getBlockLanguage(block: ProsemirrorNode): string {
 }
 
 /**
+ * Gets the language string from a code_block node, returning the auto-detected language if one wasn't specified
+ * @param block The block to get the language string from
+ */
+export function getBlockLanguage(block: ProsemirrorNode): {
+    Language: string;
+    IsAutoDetected: boolean;
+} {
+    // if a language has been specified with three backticks, use that
+    const specifiedLanguage = getSpecifiedBlockLanguage(block);
+    if (specifiedLanguage)
+        return { Language: specifiedLanguage, IsAutoDetected: false };
+
+    // otherwise use the cached autodetected language
+    return {
+        Language: block.attrs.autodetectedLanguage as string,
+        IsAutoDetected: true,
+    };
+}
+
+/**
  * Plugin that highlights all code within all code_blocks in the parent
  */
 export function CodeBlockHighlightPlugin(): Plugin {
-    const extractor = (block: ProsemirrorNode) => {
-        // if a language has been specified with three backticks, use that
-        const specifiedLanguage = getBlockLanguage(block);
-        if (specifiedLanguage) return specifiedLanguage;
-
-        // otherwise use the cached autodetected language
-        return block.attrs.autodetectedLanguage as string;
-    };
+    const extractor = (block: ProsemirrorNode) =>
+        getBlockLanguage(block).Language;
 
     const setter = (
         tr: Transaction,

--- a/src/shared/highlighting/highlight-plugin.ts
+++ b/src/shared/highlighting/highlight-plugin.ts
@@ -107,10 +107,12 @@ export function getBlockLanguage(
  */
 export function CodeBlockHighlightPlugin(): Plugin {
     const extractor = (block: ProsemirrorNode) => {
-        const detectedLanguage = block.attrs.language as string;
-        return (
-            detectedLanguage || getBlockLanguage(block)
-        );
+        // if a language has been specified with three backticks, use that
+        const specifiedLanguage = getBlockLanguage(block);
+        if (specifiedLanguage) return specifiedLanguage;
+
+        // otherwise use the cached autodetected language
+        return block.attrs.autodetectedLanguage as string;
     };
 
     const setter = (
@@ -121,7 +123,7 @@ export function CodeBlockHighlightPlugin(): Plugin {
     ): Transaction => {
         const attrs = { ...node.attrs };
 
-        attrs["language"] = language;
+        attrs["autodetectedLanguage"] = language;
 
         return tr.setNodeMarkup(pos, undefined, attrs);
     };

--- a/src/shared/highlighting/highlight-plugin.ts
+++ b/src/shared/highlighting/highlight-plugin.ts
@@ -89,15 +89,14 @@ function dealiasLanguage(rawLanguage: string): Language {
  * @param block The block to get the language string from
  */
 export function getBlockLanguage(
-    block: ProsemirrorNode,
-    fallback = "none"
+    block: ProsemirrorNode
 ): string {
     // commonmark spec suggests that the "first word" in a fence's info string is the language
     // https://spec.commonmark.org/0.29/#info-string
     // https://spec.commonmark.org/0.29/#example-112
     const rawInfoString = (block.attrs.params as string) || "";
     const rawLanguage =
-        rawInfoString.split(/\s/)[0].toLowerCase() || fallback || null;
+        rawInfoString.split(/\s/)[0].toLowerCase() || null;
 
     // attempt to dealias the language before sending out to the highlighter
     return dealiasLanguage(rawLanguage);
@@ -110,7 +109,7 @@ export function CodeBlockHighlightPlugin(): Plugin {
     const extractor = (block: ProsemirrorNode) => {
         const detectedLanguage = block.attrs.language as string;
         return (
-            detectedLanguage || getBlockLanguage(block, null)
+            detectedLanguage || getBlockLanguage(block)
         );
     };
 


### PR DESCRIPTION
This is another PR that is a precursor to adding a language picker dropdown to codeblocks, In the interests of keeping things small and reviewable.

There are no functional changes in this PR, but I've rearranged various things to make the current behaviour a little more explicit.

Code changes:
- removed `codeblockOverrideLanguage` from the options, as this is not used. The intention of this setting was to provide a default fallback language, presumably from a question's tags on Stack Overflow. But we're not using it (and a question can have multiple tags, so arguably this is not a useful design)
- there is logic for caching the auto-detected language from HighlightJS. This was stored in a node's `language` attribute, but since it's _only_ for the auto-detected language (and not for when a user specifies one directly), I've renamed that to `autodectedLanguage` to make it clearer.
- in functions that return the language for a codeblock, made it explicit that the user-specified language takes precedence. Previously this worked "by accident" in a way, because the auto-detected language would be unset in this case.
- make it clearer that the previously-named `language` field on the code block element is the title for the language indicator, which has "(auto)" appended if it's an auto-detected language