### PR TITLE
Changeset catchup to latest release (should be 0.11.1)

### DIFF
--- a/.changeset/four-carrots-remain.md
+++ b/.changeset/four-carrots-remain.md
@@ -1,0 +1,9 @@
+---
+"@stackoverflow/stacks-editor": minor
+---
+
+- Added Stack Snippets support
+- Moved around External Plugins for QoL improvements
+- Added a parameter to control image uploader file size limit
+- Moved to changeset version control
+- Removed extraneous code for code block processors


### PR DESCRIPTION
This is a seperate changeset release to track changes up from 0.10.11 -> (hopefully) 0.11.1.

Typically these files would be produced alongside changes, but we have only recently moved to changeset, and wanted a means of tracking this intialization seperate from the GH action workflow changes.