### PR TITLE
fix(styles): moving styles to stacks css classes, adding positioning

### DIFF
--- a/.changeset/some-facts-learn.md
+++ b/.changeset/some-facts-learn.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-editor": patch
+---
+
+Refactor inline styling to stacks css classes, adding positioning class

--- a/plugins/official/stack-snippets/src/snippet-view.ts
+++ b/plugins/official/stack-snippets/src/snippet-view.ts
@@ -127,14 +127,11 @@ export class StackSnippetView implements NodeView {
             //Clear the node
             this.resultContainer.innerHTML = "";
             const iframe = document.createElement("iframe");
-            iframe.className = "snippet-box-edit snippet-box-result";
+            iframe.className = "snippet-box-edit snippet-box-result ps-relative w100 hmn0 baw0";
             iframe.setAttribute(
                 "sandbox",
                 "allow-forms allow-modals allow-scripts"
             );
-            iframe.style.width = "100%";
-            iframe.style.border = "0px";
-            iframe.style.minHeight = "300px";
             if (content.nodeType === Node.DOCUMENT_NODE) {
                 const document = <Document>content;
                 iframe.srcdoc = document.documentElement.innerHTML;


### PR DESCRIPTION
**Describe your changes**

Fixes the Snippets plugin to use Stacks atomic classes, and adds a `positioning` element to fix a rendering error when used in the SO codebase.

**PR Checklist**

- [ ] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [ ] All new/changed functions have `/** ... */` docs
- [ ] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: desktop
- OS: Windows
- Browser: chrome
- Version: 135.0.7049.42