### PR TITLE
feat(snippets): show/hide link functionality

### DIFF
--- a/.changeset/fifty-tips-listen.md
+++ b/.changeset/fifty-tips-listen.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-editor": minor
+---
+
+Adds show/hide functionality to Snippets

--- a/plugins/official/stack-snippets/src/schema.ts
+++ b/plugins/official/stack-snippets/src/schema.ts
@@ -170,6 +170,7 @@ export const stackSnippetRichTextNodeSpec: { [name: string]: NodeSpec } = {
             babel: { default: "null" },
             babelPresetReact: { default: "null" },
             babelPresetTS: { default: "null" },
+            showCode: { default: true }
         },
     },
     stack_snippet_lang: {

--- a/plugins/official/stack-snippets/src/schema.ts
+++ b/plugins/official/stack-snippets/src/schema.ts
@@ -170,7 +170,7 @@ export const stackSnippetRichTextNodeSpec: { [name: string]: NodeSpec } = {
             babel: { default: "null" },
             babelPresetReact: { default: "null" },
             babelPresetTS: { default: "null" },
-            showCode: { default: true }
+            showCode: { default: true },
         },
     },
     stack_snippet_lang: {

--- a/plugins/official/stack-snippets/src/snippet-view.ts
+++ b/plugins/official/stack-snippets/src/snippet-view.ts
@@ -47,7 +47,7 @@ export class StackSnippetView implements NodeView {
             const toggleLink = document.createElement("a");
             toggleLink.href = "#";
             toggleLink.className = "snippet-toggle fs-body1";
-            toggleLink.textContent = codeIsShown ? "Hide Code" : "Show Code";
+            toggleLink.textContent = codeIsShown ? "Hide code snippet" : "Show code snippet";
             toggleContainer.appendChild(toggleLink);
 
             snippetContainer.appendChild(toggleContainer);
@@ -171,7 +171,7 @@ e
 
         const isVisible = node.attrs.showCode as boolean;
         snippetCode.style.display = isVisible ? "" : "none";
-        toggleLink.textContent = isVisible ? "Hide Code" : "Show Code";
+        toggleLink.textContent = isVisible ? "Hide code snippet" : "Show code snippet";
         arrowSpan.className = isVisible
             ? "svg-icon-bg iconArrowDownSm va-middle"
             : "svg-icon-bg iconArrowRightSm va-middle";

--- a/plugins/official/stack-snippets/src/snippet-view.ts
+++ b/plugins/official/stack-snippets/src/snippet-view.ts
@@ -166,19 +166,22 @@ export class StackSnippetView implements NodeView {
             JSON.stringify(this.snippetMetadata);
         this.snippetMetadata = updatedMeta;
 
-        // Update the visibility of the snippet-code div and toggle link
-        const snippetCode = this.contentDOM;
-        const toggleLink = this.dom.querySelector(".snippet-toggle");
-        const arrowSpan = this.dom.querySelector(".svg-icon-bg");
+        if (this.snippetMetadata.hide === "true") {
 
-        const isVisible = node.attrs.showCode as boolean;
-        snippetCode.style.display = isVisible ? "" : "none";
-        toggleLink.textContent = isVisible
-            ? "Hide code snippet"
-            : "Show code snippet";
-        arrowSpan.className = isVisible
-            ? "svg-icon-bg iconArrowDownSm va-middle"
-            : "svg-icon-bg iconArrowRightSm va-middle";
+            // Update the visibility of the snippet-code div and toggle link
+            const snippetCode = this.contentDOM;
+            const toggleLink = this.dom.querySelector(".snippet-toggle");
+            const arrowSpan = this.dom.querySelector(".svg-icon-bg");
+
+            const isVisible = node.attrs.showCode as boolean;
+            snippetCode.style.display = isVisible ? "" : "none";
+            toggleLink.textContent = isVisible
+                ? "Hide code snippet"
+                : "Show code snippet";
+            arrowSpan.className = isVisible
+                ? "svg-icon-bg iconArrowDownSm va-middle"
+                : "svg-icon-bg iconArrowRightSm va-middle";
+        }
 
         // Update the result container if metadata has changed
         const content = this.contentNode;

--- a/plugins/official/stack-snippets/src/snippet-view.ts
+++ b/plugins/official/stack-snippets/src/snippet-view.ts
@@ -178,8 +178,8 @@ export class StackSnippetView implements NodeView {
                 ? "Hide code snippet"
                 : "Show code snippet";
             arrowSpan.className = isVisible
-                ? "svg-icon-bg iconArrowDownSm va-middle"
-                : "svg-icon-bg iconArrowRightSm va-middle";
+                ? "svg-icon-bg iconArrowDownSm"
+                : "svg-icon-bg iconArrowRightSm";
         }
 
         // Update the result container if metadata has changed

--- a/plugins/official/stack-snippets/src/snippet-view.ts
+++ b/plugins/official/stack-snippets/src/snippet-view.ts
@@ -167,7 +167,6 @@ export class StackSnippetView implements NodeView {
         this.snippetMetadata = updatedMeta;
 
         if (this.snippetMetadata.hide === "true") {
-
             // Update the visibility of the snippet-code div and toggle link
             const snippetCode = this.contentDOM;
             const toggleLink = this.dom.querySelector(".snippet-toggle");

--- a/plugins/official/stack-snippets/src/snippet-view.ts
+++ b/plugins/official/stack-snippets/src/snippet-view.ts
@@ -35,13 +35,14 @@ export class StackSnippetView implements NodeView {
         if (this.snippetMetadata.hide === "true") {
             // Create the show/hide link container
             toggleContainer = document.createElement("div");
-            toggleContainer.className = "snippet-toggle-container";
+            toggleContainer.className =
+                "snippet-toggle-container d-inline-flex ai-center g2";
 
             // Create the arrow span
             const arrowSpan = document.createElement("span");
             arrowSpan.className = codeIsShown
-                ? "svg-icon-bg iconArrowDownSm va-middle"
-                : "svg-icon-bg iconArrowRightSm va-middle";
+                ? "svg-icon-bg iconArrowDownSm"
+                : "svg-icon-bg iconArrowRightSm";
             toggleContainer.appendChild(arrowSpan);
 
             // Create the show/hide link

--- a/plugins/official/stack-snippets/src/snippet-view.ts
+++ b/plugins/official/stack-snippets/src/snippet-view.ts
@@ -19,6 +19,9 @@ export class StackSnippetView implements NodeView {
         this.getPos = getPos;
 
         this.snippetMetadata = getSnippetMetadata(node);
+        const codeIsShown: boolean = typeof node.attrs.showCode === "boolean"
+            ? node.attrs.showCode
+            : true;
 
         //We want to render the language blocks in the middle of some content,
         // so we need to custom-render stuff here ("holes" must be last)
@@ -26,11 +29,50 @@ export class StackSnippetView implements NodeView {
         this.dom = snippetContainer;
         snippetContainer.className = "snippet";
 
+        let toggleContainer: HTMLDivElement;
+
+        if (this.snippetMetadata.hide === "true") {
+            // Create the show/hide link container
+            toggleContainer = document.createElement("div");
+            toggleContainer.className = "snippet-toggle-container";
+
+            // Create the arrow span
+            const arrowSpan = document.createElement("span");
+            arrowSpan.className = codeIsShown
+                ? "svg-icon-bg iconArrowDownSm va-middle"
+                : "svg-icon-bg iconArrowRightSm va-middle";
+            toggleContainer.appendChild(arrowSpan);
+
+            // Create the show/hide link
+            const toggleLink = document.createElement("a");
+            toggleLink.href = "#";
+            toggleLink.className = "snippet-toggle fs-body1";
+            toggleLink.textContent = codeIsShown ? "Hide Code" : "Show Code";
+            toggleContainer.appendChild(toggleLink);
+
+            snippetContainer.appendChild(toggleContainer);
+        }
+
         //This is the div where we're going to render any language blocks
         const snippetCode = document.createElement("div");
         snippetCode.className = "snippet-code";
+        snippetCode.style.display = codeIsShown ? "" : "none"; 
         snippetContainer.appendChild(snippetCode);
         this.contentDOM = snippetCode;
+
+        if (this.snippetMetadata.hide === "true") {
+            toggleContainer.addEventListener("click", (e) => {
+                e.preventDefault();
+                const isVisible = snippetCode.style.display !== "none";
+e
+                this.view.dispatch(
+                    this.view.state.tr.setNodeMarkup(this.getPos(), null, {
+                        ...node.attrs,
+                        showCode: !isVisible,
+                    })
+                );
+            });
+        }
 
         //And this is where we stash our CTAs and results, which are statically rendered.
         const snippetResult = document.createElement("div");
@@ -122,6 +164,19 @@ export class StackSnippetView implements NodeView {
             JSON.stringify(this.snippetMetadata);
         this.snippetMetadata = updatedMeta;
 
+        // Update the visibility of the snippet-code div and toggle link
+        const snippetCode = this.contentDOM;
+        const toggleLink = this.dom.querySelector(".snippet-toggle");
+        const arrowSpan = this.dom.querySelector(".svg-icon-bg");
+
+        const isVisible = node.attrs.showCode as boolean;
+        snippetCode.style.display = isVisible ? "" : "none";
+        toggleLink.textContent = isVisible ? "Hide Code" : "Show Code";
+        arrowSpan.className = isVisible
+            ? "svg-icon-bg iconArrowDownSm va-middle"
+            : "svg-icon-bg iconArrowRightSm va-middle";
+
+        // Update the result container if metadata has changed
         const content = this.contentNode;
         if (metaChanged && content) {
             //Clear the node
@@ -134,7 +189,7 @@ export class StackSnippetView implements NodeView {
                 "allow-forms allow-modals allow-scripts"
             );
             if (content.nodeType === Node.DOCUMENT_NODE) {
-                const document = <Document>content;
+                const document = content as Document;
                 iframe.srcdoc = document.documentElement.innerHTML;
             }
             this.resultContainer.appendChild(iframe);
@@ -148,6 +203,6 @@ export class StackSnippetView implements NodeView {
     private contentNode: Node;
     private getPos: () => number;
     resultContainer: HTMLDivElement;
-    dom: Node;
+    dom: HTMLElement;
     contentDOM: HTMLElement;
 }

--- a/plugins/official/stack-snippets/src/snippet-view.ts
+++ b/plugins/official/stack-snippets/src/snippet-view.ts
@@ -19,9 +19,10 @@ export class StackSnippetView implements NodeView {
         this.getPos = getPos;
 
         this.snippetMetadata = getSnippetMetadata(node);
-        const codeIsShown: boolean = typeof node.attrs.showCode === "boolean"
-            ? node.attrs.showCode
-            : true;
+        const codeIsShown: boolean =
+            typeof node.attrs.showCode === "boolean"
+                ? node.attrs.showCode
+                : true;
 
         //We want to render the language blocks in the middle of some content,
         // so we need to custom-render stuff here ("holes" must be last)
@@ -47,7 +48,9 @@ export class StackSnippetView implements NodeView {
             const toggleLink = document.createElement("a");
             toggleLink.href = "#";
             toggleLink.className = "snippet-toggle fs-body1";
-            toggleLink.textContent = codeIsShown ? "Hide code snippet" : "Show code snippet";
+            toggleLink.textContent = codeIsShown
+                ? "Hide code snippet"
+                : "Show code snippet";
             toggleContainer.appendChild(toggleLink);
 
             snippetContainer.appendChild(toggleContainer);
@@ -56,7 +59,7 @@ export class StackSnippetView implements NodeView {
         //This is the div where we're going to render any language blocks
         const snippetCode = document.createElement("div");
         snippetCode.className = "snippet-code";
-        snippetCode.style.display = codeIsShown ? "" : "none"; 
+        snippetCode.style.display = codeIsShown ? "" : "none";
         snippetContainer.appendChild(snippetCode);
         this.contentDOM = snippetCode;
 
@@ -64,7 +67,6 @@ export class StackSnippetView implements NodeView {
             toggleContainer.addEventListener("click", (e) => {
                 e.preventDefault();
                 const isVisible = snippetCode.style.display !== "none";
-e
                 this.view.dispatch(
                     this.view.state.tr.setNodeMarkup(this.getPos(), null, {
                         ...node.attrs,
@@ -171,7 +173,9 @@ e
 
         const isVisible = node.attrs.showCode as boolean;
         snippetCode.style.display = isVisible ? "" : "none";
-        toggleLink.textContent = isVisible ? "Hide code snippet" : "Show code snippet";
+        toggleLink.textContent = isVisible
+            ? "Hide code snippet"
+            : "Show code snippet";
         arrowSpan.className = isVisible
             ? "svg-icon-bg iconArrowDownSm va-middle"
             : "svg-icon-bg iconArrowRightSm va-middle";

--- a/plugins/official/stack-snippets/test/snippet-view.test.ts
+++ b/plugins/official/stack-snippets/test/snippet-view.test.ts
@@ -27,7 +27,10 @@ describe("StackSnippetView", () => {
             langNode
         );
 
-    const buildView = (options?: StackSnippetOptions, hide: string = "false"): EditorView => {
+    const buildView = (
+        options?: StackSnippetOptions,
+        hide: string = "false"
+    ): EditorView => {
         const state = EditorState.create({
             schema: schema,
             plugins: [stackSnippetPasteHandler],

--- a/src/styles/icons.css
+++ b/src/styles/icons.css
@@ -13,3 +13,9 @@
 .svg-icon-bg.iconEllipsisHorizontal {
     --bg-icon: url("~@stackoverflow/stacks-icons/src/Icon/EllipsisHorizontal.svg");
 }
+.svg-icon-bg.iconArrowDownSm {
+    --bg-icon: url("~@stackoverflow/stacks-icons/src/Icon/ArrowDownSm.svg");
+}
+.svg-icon-bg.iconArrowRightSm {
+    --bg-icon: url("~@stackoverflow/stacks-icons/src/Icon/ArrowRightSm.svg");
+}


### PR DESCRIPTION
[Jira issue](https://stackoverflow.atlassian.net/browse/DISCOCD-81)

**Describe your changes**

Adds a "Show/Hide" link to toggle the visibility of code snippets (not the results pane) in the StackSnippetView. This corresponds to how snippets preview worked in the old editor. The link is only rendered when the hide attribute is "true". 

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [ ] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: desktop
- OS: [e.g. iOS]
- Browser: chrome
- Version [e.g. 22]

**Additional context**

TODO: Need to add the same functionality to the preview pane in the MD+P mode. 