### PR TITLE
Amend an existing snippet.

### DIFF
--- a/.changeset/hip-forks-kiss.md
+++ b/.changeset/hip-forks-kiss.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-editor": minor
+---
+
+Add the ability to edit a Snippet in place (via callback)

--- a/plugins/official/stack-snippets/src/commands.ts
+++ b/plugins/official/stack-snippets/src/commands.ts
@@ -1,9 +1,68 @@
 import { MenuCommand } from "../../../../src";
-import { getSnippetMetadata, StackSnippetOptions } from "./common";
+import {
+    getSnippetMetadata,
+    SnippetMetadata,
+    StackSnippetOptions,
+} from "./common";
 import { Node } from "prosemirror-model";
+import { EditorView } from "prosemirror-view";
+import { BASE_VIEW_KEY } from "../../../../src/shared/prosemirror-plugins/base-view-state";
+
+/** Builds a function that will update a snippet node on the up-to-date state (at time of execution) **/
+function buildUpdateDocumentCallback(view: EditorView) {
+    return (id: SnippetMetadata["id"], markdown: string): void => {
+        //Search for the id
+        let identifiedNode: Node;
+        let identifiedPos: number;
+        view.state.doc.descendants((node, pos) => {
+            if (node.type.name == "stack_snippet" && node.attrs?.id == id) {
+                identifiedNode = node;
+                identifiedPos = pos;
+            }
+
+            //We never want to delve into children
+            return false;
+        });
+
+        //Get an entrypoint into the BaseView we're in currently
+        const { baseView } = BASE_VIEW_KEY.getState(view.state);
+
+        //We didn't find something to replace, so we're inserting it
+        if (!identifiedNode) {
+            baseView.appendContent(markdown);
+        } else {
+            //Parse the incoming markdown as a Prosemirror node using the same entry point as everything else
+            // (this makes sure there's a single pathway for parsing content)
+            const parsedNodeDoc: Node = baseView.parseContent(markdown);
+            let node: Node;
+            if (parsedNodeDoc.childCount != 1) {
+                //There's been a parsing error. Put the whole doc in it's place.
+                node = parsedNodeDoc;
+            } else {
+                //The parsed node has a new ID, but we want to maintain it.
+                // That said, we can only amend Attrs on a rendered node, but doing so makes for a busy
+                // transaction dispatch history
+                //Solution: Reparse the node, amending the JSON inbetween.
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                const snippetNodeJson = parsedNodeDoc.firstChild.toJSON();
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                snippetNodeJson.attrs.id = id;
+                node = Node.fromJSON(view.state.schema, snippetNodeJson);
+            }
+
+            view.dispatch(
+                view.state.tr.replaceWith(
+                    identifiedPos,
+                    identifiedPos + identifiedNode.nodeSize,
+                    node
+                )
+            );
+        }
+    };
+}
 
 export function openSnippetModal(options?: StackSnippetOptions): MenuCommand {
-    return (state, dispatch): boolean => {
+    return (state, dispatch, view): boolean => {
         //If we have no means of opening a modal, reject immediately
         if (!options || options.openSnippetsModal == undefined) {
             return false;
@@ -29,7 +88,7 @@ export function openSnippetModal(options?: StackSnippetOptions): MenuCommand {
         //Just grab the first node highlighted and dispatch that. If not, dispatch nothing
         if (discoveredSnippets.length == 0) {
             //Fire the open modal handler with nothing
-            options.openSnippetsModal();
+            options.openSnippetsModal(buildUpdateDocumentCallback(view));
             return true;
         }
 
@@ -45,6 +104,7 @@ export function openSnippetModal(options?: StackSnippetOptions): MenuCommand {
         );
 
         options.openSnippetsModal(
+            buildUpdateDocumentCallback(view),
             snippetMetadata,
             js?.content,
             css?.content,

--- a/plugins/official/stack-snippets/src/commands.ts
+++ b/plugins/official/stack-snippets/src/commands.ts
@@ -10,7 +10,7 @@ import { BASE_VIEW_KEY } from "../../../../src/shared/prosemirror-plugins/base-v
 
 /** Builds a function that will update a snippet node on the up-to-date state (at time of execution) **/
 function buildUpdateDocumentCallback(view: EditorView) {
-    return (id: SnippetMetadata["id"], markdown: string): void => {
+    return (markdown: string, id: SnippetMetadata["id"]): void => {
         //Search for the id
         let identifiedNode: Node;
         let identifiedPos: number;

--- a/plugins/official/stack-snippets/src/commands.ts
+++ b/plugins/official/stack-snippets/src/commands.ts
@@ -10,19 +10,21 @@ import { BASE_VIEW_KEY } from "../../../../src/shared/prosemirror-plugins/base-v
 
 /** Builds a function that will update a snippet node on the up-to-date state (at time of execution) **/
 function buildUpdateDocumentCallback(view: EditorView) {
-    return (markdown: string, id: SnippetMetadata["id"]): void => {
+    return (markdown: string, id?: SnippetMetadata["id"]): void => {
         //Search for the id
         let identifiedNode: Node;
         let identifiedPos: number;
-        view.state.doc.descendants((node, pos) => {
-            if (node.type.name == "stack_snippet" && node.attrs?.id == id) {
-                identifiedNode = node;
-                identifiedPos = pos;
-            }
+        if(id !== undefined) {
+            view.state.doc.descendants((node, pos) => {
+                if (node.type.name == "stack_snippet" && node.attrs?.id == id) {
+                    identifiedNode = node;
+                    identifiedPos = pos;
+                }
 
-            //We never want to delve into children
-            return false;
-        });
+                //We never want to delve into children
+                return false;
+            });
+        }
 
         //Get an entrypoint into the BaseView we're in currently
         const { baseView } = BASE_VIEW_KEY.getState(view.state);

--- a/plugins/official/stack-snippets/src/commands.ts
+++ b/plugins/official/stack-snippets/src/commands.ts
@@ -14,7 +14,7 @@ function buildUpdateDocumentCallback(view: EditorView) {
         //Search for the id
         let identifiedNode: Node;
         let identifiedPos: number;
-        if(id !== undefined) {
+        if (id !== undefined) {
             view.state.doc.descendants((node, pos) => {
                 if (node.type.name == "stack_snippet" && node.attrs?.id == id) {
                     identifiedNode = node;

--- a/plugins/official/stack-snippets/src/common.ts
+++ b/plugins/official/stack-snippets/src/common.ts
@@ -12,6 +12,10 @@ export interface StackSnippetOptions {
 
     /** Function to trigger opening of the snippets Modal */
     openSnippetsModal: (
+        updateDocumentCallback: (
+            id: SnippetMetadata["id"],
+            markdown?: string
+        ) => void,
         meta?: SnippetMetadata,
         js?: string,
         css?: string,

--- a/plugins/official/stack-snippets/src/common.ts
+++ b/plugins/official/stack-snippets/src/common.ts
@@ -13,8 +13,8 @@ export interface StackSnippetOptions {
     /** Function to trigger opening of the snippets Modal */
     openSnippetsModal: (
         updateDocumentCallback: (
-            id: SnippetMetadata["id"],
-            markdown?: string
+            markdown: string,
+            id?: SnippetMetadata["id"]
         ) => void,
         meta?: SnippetMetadata,
         js?: string,

--- a/plugins/official/stack-snippets/test/commands.test.ts
+++ b/plugins/official/stack-snippets/test/commands.test.ts
@@ -198,7 +198,7 @@ describe("commands", () => {
                 const view = richView("");
 
                 //Capture the metadata (for the Id) and the callback
-                let captureCallback: (markdown?: string) => void;
+                let captureCallback: (markdown: string) => void;
                 const snippetOptions: StackSnippetOptions = {
                     renderer: () => Promise.resolve(null),
                     openSnippetsModal: (updateDocumentCallback) => {

--- a/plugins/official/stack-snippets/test/commands.test.ts
+++ b/plugins/official/stack-snippets/test/commands.test.ts
@@ -1,12 +1,19 @@
+import { Node } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import { SnippetMetadata, StackSnippetOptions } from "../src/common";
 import { openSnippetModal } from "../src/commands";
 import { RichTextHelpers } from "../../../../test";
 import {
     buildSnippetSchema,
+    snippetExternalProvider,
+    validBegin,
+    validEnd,
     validSnippetRenderCases,
 } from "./stack-snippet-helpers";
 import { parseSnippetBlockForProsemirror } from "../src/paste-handler";
+import { RichTextEditor } from "../../../../src";
+import { stackSnippetPlugin as markdownPlugin } from "../src/schema";
+import MarkdownIt from "markdown-it";
 
 describe("commands", () => {
     const schema = buildSnippetSchema();
@@ -19,14 +26,14 @@ describe("commands", () => {
             css?: string,
             html?: string
         ) => boolean
-    ) => {
+    ): boolean => {
         let captureMeta: SnippetMetadata = null;
         let captureJs: string = null;
         let captureCss: string = null;
         let captureHtml: string = null;
         const snippetOptions: StackSnippetOptions = {
             renderer: () => Promise.resolve(null),
-            openSnippetsModal: (meta, js, css, html) => {
+            openSnippetsModal: (_, meta, js, css, html) => {
                 captureMeta = meta;
                 captureJs = js;
                 captureCss = css;
@@ -40,73 +47,144 @@ describe("commands", () => {
         expect(
             shouldMatchCall(captureMeta, captureJs, captureCss, captureHtml)
         ).toBe(true);
+
+        //Essentially the expects will mean this is terminated before now.
+        // We can now expect on this guy to get rid of the linting errors
+        return true;
     };
 
-    it("should do nothing if dispatch null", () => {
-        const snippetOptions: StackSnippetOptions = {
-            renderer: () => Promise.resolve(null),
-            openSnippetsModal: () => {},
-        };
-        const state = RichTextHelpers.createState(
-            "Here's a paragraph -  a text block mind you",
-            []
-        );
-
-        const command = openSnippetModal(snippetOptions);
-
-        const ret = command(state, null);
-
-        expect(ret).toBe(true);
-    });
-
-    it("should send openModal with blank arguments if no snippet detected", () => {
-        const state = RichTextHelpers.createState(
-            "Here's a paragraph -  a text block mind you",
-            []
-        );
-
-        whenOpenSnippetCommandCalled(state, (meta, js, css, html) => {
-            //Expect a blank modal
-            if (meta || js || css || html) {
-                return false;
-            }
-            return true;
-        });
-    });
-
-    it.each(validSnippetRenderCases)(
-        "should send openModal with blank arguments if snippet detected",
-        (markdown: string, langs: string[]) => {
-            //Create a blank doc, then replace the contents (a paragraph node) with the parsed markdown.
-            let state = EditorState.create({
-                schema: schema,
-                plugins: [],
-            });
-            state = state.apply(
-                state.tr.replaceRangeWith(
-                    0,
-                    state.doc.nodeSize - 2,
-                    parseSnippetBlockForProsemirror(schema, markdown)
-                )
+    describe("dispatch", () => {
+        it("should do nothing if dispatch null", () => {
+            const snippetOptions: StackSnippetOptions = {
+                renderer: () => Promise.resolve(null),
+                openSnippetsModal: () => {},
+            };
+            const state = RichTextHelpers.createState(
+                "Here's a paragraph -  a text block mind you",
+                []
             );
 
-            //Anywhere selection poision is now meaningfully a part of the stack snippet, so open the modal and expect it to be passed
-            whenOpenSnippetCommandCalled(state, (meta, js, css, html) => {
-                if (!meta) {
-                    return false;
-                }
-                if ("js" in langs) {
-                    if (js === undefined) return false;
-                }
-                if ("css" in langs) {
-                    if (css === undefined) return false;
-                }
-                if ("html" in langs) {
-                    if (html === undefined) return false;
-                }
+            const command = openSnippetModal(snippetOptions);
 
-                return true;
-            });
+            const ret = command(state, null);
+
+            expect(ret).toBe(true);
+        });
+
+        it("should send openModal with blank arguments if no snippet detected", () => {
+            const state = RichTextHelpers.createState(
+                "Here's a paragraph -  a text block mind you",
+                []
+            );
+
+            expect(
+                whenOpenSnippetCommandCalled(state, (meta, js, css, html) => {
+                    //Expect a blank modal
+                    return !(meta || js || css || html);
+                })
+            ).toBe(true);
+        });
+
+        it.each(validSnippetRenderCases)(
+            "should send openModal with arguments if snippet detected",
+            (markdown: string, langs: string[]) => {
+                //Create a blank doc, then replace the contents (a paragraph node) with the parsed markdown.
+                let state = EditorState.create({
+                    schema: schema,
+                    plugins: [],
+                });
+                state = state.apply(
+                    state.tr.replaceRangeWith(
+                        0,
+                        state.doc.nodeSize - 2,
+                        parseSnippetBlockForProsemirror(schema, markdown)
+                    )
+                );
+
+                //Anywhere selection position is now meaningfully a part of the stack snippet, so open the modal and expect it to be passed
+                expect(
+                    whenOpenSnippetCommandCalled(
+                        state,
+                        (meta, js, css, html) => {
+                            if (!meta) {
+                                return false;
+                            }
+                            if ("js" in langs) {
+                                if (js === undefined) return false;
+                            }
+                            if ("css" in langs) {
+                                if (css === undefined) return false;
+                            }
+                            if ("html" in langs) {
+                                if (html === undefined) return false;
+                            }
+
+                            return true;
+                        }
+                    )
+                ).toBe(true);
+            }
+        );
+    });
+
+    describe("callback", () => {
+        const mdit = new MarkdownIt("default", {});
+        mdit.use(markdownPlugin);
+        function richView(markdownInput: string, opts?: StackSnippetOptions) {
+            return new RichTextEditor(
+                document.createElement("div"),
+                markdownInput,
+                snippetExternalProvider(opts),
+                {}
+            );
         }
-    );
+
+        const callbackTestCaseJs: string = `<!-- language: lang-js -->
+
+    console.log("callbackTestCase");
+
+`;
+        const starterCallbackSnippet = `${validBegin}${callbackTestCaseJs}${validEnd}`;
+
+        it.each(validSnippetRenderCases)(
+            "should replace existing snippet when editDocumentCallback is called",
+            (markdown: string) => {
+                //Create a blank doc, then replace the contents (a paragraph node) with the parsed markdown.
+                const view = richView(starterCallbackSnippet);
+
+                //Capture the metadata (for the Id) and the callback
+                let captureMeta: SnippetMetadata = null;
+                let captureCallback: (
+                    id: SnippetMetadata["id"],
+                    markdown?: string
+                ) => void;
+                const snippetOptions: StackSnippetOptions = {
+                    renderer: () => Promise.resolve(null),
+                    openSnippetsModal: (editDocumentCallback, meta) => {
+                        captureMeta = meta;
+                        captureCallback = editDocumentCallback;
+                    },
+                };
+                openSnippetModal(snippetOptions)(
+                    view.editorView.state,
+                    () => {},
+                    view.editorView
+                );
+
+                //Call the callback
+                captureCallback(captureMeta.id, markdown);
+
+                //Assert that the current view state has been changed
+                let matchingNodes: Node[] = [];
+                view.editorView.state.doc.descendants((node) => {
+                    if (node.type.name == "stack_snippet") {
+                        if (node.attrs.id == captureMeta.id) {
+                            matchingNodes = [...matchingNodes, node];
+                        }
+                    }
+                });
+                expect(matchingNodes).toHaveLength(1);
+            }
+        );
+    });
 });

--- a/site/index.ts
+++ b/site/index.ts
@@ -126,7 +126,7 @@ const ImageUploadHandler: ImageUploadOptions["handler"] = (file) =>
     });
 
 const stackSnippetOpts: StackSnippetOptions = {
-    renderer: (meta, js, css, html) => {
+    renderer: async (meta, js, css, html) => {
         const data = {
             js: js,
             css: css,
@@ -136,27 +136,26 @@ const stackSnippetOpts: StackSnippetOptions = {
             babelPresetReact: meta.babelPresetReact,
             babelPresetTS: meta.babelPresetTS,
         };
-        return fetch("/snippets/js", {
-            method: "POST",
-            body: new URLSearchParams(data),
-        })
-            .then((res) => res.text())
-            .then((html) => {
-                const parser = new DOMParser();
-                const doc = parser.parseFromString(html, "text/html");
-                return doc;
-            })
-            .catch((err) => {
-                error("test harness - snippet render", err);
-                const div = document.createElement("div");
-                const freeRealEstate = document.createElement("img");
-                freeRealEstate.src =
-                    "https://i.kym-cdn.com/entries/icons/original/000/021/311/free.jpg";
-                div.appendChild(freeRealEstate);
-                return div;
+        try {
+            const res = await fetch("/snippets/js", {
+                method: "POST",
+                body: new URLSearchParams(data),
             });
+            const html = await res.text();
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, "text/html");
+            return doc;
+        } catch (err) {
+            error("test harness - snippet render", err);
+            const div = document.createElement("div");
+            const freeRealEstate = document.createElement("img");
+            freeRealEstate.src =
+                "https://i.kym-cdn.com/entries/icons/original/000/021/311/free.jpg";
+            div.appendChild(freeRealEstate);
+            return div;
+        }
     },
-    openSnippetsModal: (meta, js, css, html) => {
+    openSnippetsModal: (editorCallback, meta, js, css, html) => {
         log("test harness - open modal event", `meta\n${JSON.stringify(meta)}`);
         log("test harness - open modal event", `js\n${JSON.stringify(js)}`);
         log("test harness - open modal event", `css\n${JSON.stringify(css)}`);

--- a/src/commonmark/editor.ts
+++ b/src/commonmark/editor.ts
@@ -30,6 +30,7 @@ import { commonmarkSchema } from "./schema";
 import { textCopyHandlerPlugin } from "./plugins/text-copy-handler";
 import { markdownHighlightPlugin } from "./plugins/markdown-highlight";
 import { createMenuEntries } from "../shared/menu";
+import { baseViewStatePlugin } from "../shared/prosemirror-plugins/base-view-state";
 
 /**
  * Describes the callback for when an html preview should be rendered
@@ -100,6 +101,7 @@ export class CommonmarkEditor extends BaseView {
                 state: EditorState.create({
                     doc: this.parseContent(content),
                     plugins: [
+                        baseViewStatePlugin(this),
                         history(),
                         ...allKeymaps(this.options.parserFeatures),
                         menu,

--- a/src/rich-text/editor.ts
+++ b/src/rich-text/editor.ts
@@ -43,6 +43,7 @@ import { interfaceManagerPlugin } from "../shared/prosemirror-plugins/interface-
 import { IExternalPluginProvider } from "../shared/editor-plugin";
 import { createMenuEntries } from "../shared/menu/index";
 import { createMenuPlugin } from "../shared/menu/plugin";
+import { baseViewStatePlugin } from "../shared/prosemirror-plugins/base-view-state";
 
 export interface RichTextOptions extends CommonViewOptions {
     /** Array of LinkPreviewProviders to handle specific link preview urls */
@@ -115,6 +116,7 @@ export class RichTextEditor extends BaseView {
                 state: EditorState.create({
                     doc: doc,
                     plugins: [
+                        baseViewStatePlugin(this),
                         history(),
                         ...allKeymaps(
                             this.finalizedSchema,

--- a/src/shared/prosemirror-plugins/base-view-state.ts
+++ b/src/shared/prosemirror-plugins/base-view-state.ts
@@ -1,0 +1,30 @@
+import { PluginKey, Plugin } from "prosemirror-state";
+import { BaseView } from "../view";
+
+interface BaseViewState {
+    baseView: BaseView;
+}
+
+export const BASE_VIEW_KEY = new PluginKey<BaseViewState>();
+
+/**
+ * A pointer to the full `BaseView` that initialized this state, such that it can be referenced in downstream plugins
+ **/
+export const baseViewStatePlugin = (
+    baseView: BaseView
+): Plugin<BaseViewState> => {
+    return new Plugin<BaseViewState>({
+        key: BASE_VIEW_KEY,
+        state: {
+            init() {
+                return {
+                    baseView,
+                };
+            },
+            apply(_, value) {
+                //View switching does not maintain state, so we always want the initialized value
+                return value;
+            },
+        },
+    });
+};


### PR DESCRIPTION
**Describe your changes**

In the Stacks Snippets plugin, we were relying on callers to append their changes to the document. This PR creates a callback parameter on the `openSnippetModal` function definition such that a function that will update the document can be called instead.

This allows us to amend existing snippets by their ID (which is available on the `snippetMetadata` passed to `openSnippetsModal`) by replacing thier contents. If it is not present, we append to the document.

**PR Checklist**

- [x] All new/changed functionality includes unit and (optionally) e2e tests as appropriate
- [x] All new/changed functions have `/** ... */` docs
- [x] I've added the `bug`/`enhancement` and other labels as appropriate

**Environment(s) tested**

- Device: desktop
- OS: Windows
- Browser: Chrome
- Version: 135.0.7049.114

**Additional context**

I ran into an issue here where the plugin is trying to interact with the markdown-it parser while during a Prosemirror flow. We bundle these together at a top level (e.g. `RichTextEditor`) which encapsulates Prosemirror's `EditorView`  and a `MarkdownSerializer` (which is ultimately served by markdown-it).
Long story short, we need a way of being able to access that encapsulation from inside the `EditorView`, and as such I've registered the `BaseViewState` (and it's Key) so that we can grab a handle on the editor, and use a familiar pathway for serialization tasks and the like.
