### PR TITLE
fix(stack-snippet): expose stack-snippet options and metadata types

### DIFF
--- a/.changeset/lemon-glasses-cheat.md
+++ b/.changeset/lemon-glasses-cheat.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-editor": patch
+---
+
+Exporting options used by the StacksSnippets plugin for user.

--- a/plugins/official/index.ts
+++ b/plugins/official/index.ts
@@ -1,2 +1,5 @@
 export { stackSnippetPlugin } from "./stack-snippets/src/stackSnippetPlugin";
-export type { StackSnippetOptions, SnippetMetadata } from "./stack-snippets/src/common";
+export type {
+    StackSnippetOptions,
+    SnippetMetadata,
+} from "./stack-snippets/src/common";

--- a/plugins/official/index.ts
+++ b/plugins/official/index.ts
@@ -1,1 +1,3 @@
 export { stackSnippetPlugin } from "./stack-snippets/src/stackSnippetPlugin";
+export { StackSnippetOptions } from "./stack-snippets/src/common";
+export { SnippetMetadata } from "./stack-snippets/src/common";


### PR DESCRIPTION
**Describe your changes**

A couple of options interfaces passed to the StacksEditor are not exported. Therefore, I had to recreate these interfaces when I wanted to use them. See: 
https://github.com/StackEng/StackOverflow/blob/571e63834ee5920c9f5db16b97b84f94c85a872d/StackOverflow/_Scripts/islands/ask-question/src/shared/stackSnippets.ts#L18

