### PR TITLE
Fixing bug thats preventing snippets from rerendering on run button click

### DIFF
--- a/plugins/official/stack-snippets/src/snippet-view.ts
+++ b/plugins/official/stack-snippets/src/snippet-view.ts
@@ -131,13 +131,7 @@ export class StackSnippetView implements NodeView {
         //Update the reference used by buttons, etc. for the most up-to-date node reference
         this.node = node;
 
-        //Check to see if the metadata has changed
-        const updatedMeta = getSnippetMetadata(node);
-        const metaChanged =
-            JSON.stringify(updatedMeta) !==
-            JSON.stringify(this.snippetMetadata);
-        this.snippetMetadata = updatedMeta;
-
+        this.snippetMetadata = getSnippetMetadata(node);
         if (this.snippetMetadata.hide === "true") {
             // Update the visibility of the snippet-code div and toggle link
             const snippetCode = this.contentDOM;
@@ -159,7 +153,6 @@ export class StackSnippetView implements NodeView {
                 : "svg-icon-bg iconArrowRightSm";
         }
 
-        // Update the result container if metadata has changed
         const content = this.contentNode;
 
         //Show the results, if the node meta allows it
@@ -231,7 +224,7 @@ export class StackSnippetView implements NodeView {
         }
 
         //Re-run execution the snippet if something has changed, or we don't yet have a result
-        if (content && (metaChanged || this.resultContainer.innerHTML === "")) {
+        if (content && (this.hasContentNodeChanged() || this.resultContainer.innerHTML === "")) {
             this.hideButton.classList.remove("d-none");
             //Clear the node
             this.resultContainer.innerHTML = "";
@@ -256,6 +249,7 @@ export class StackSnippetView implements NodeView {
     private readonly getPos: () => number;
     private snippetMetadata: SnippetMetadata;
     private contentNode: Node;
+    private contentNodeSnapshot: string;
     private showButton: HTMLButtonElement;
     private hideButton: HTMLButtonElement;
     private fullscreenButton: HTMLButtonElement;
@@ -274,6 +268,19 @@ export class StackSnippetView implements NodeView {
         "w-screen",
         "h-screen",
     ];
+
+    private hasContentNodeChanged(): boolean {
+        if (this.contentNode?.nodeType !== Node.DOCUMENT_NODE) {
+            return false;
+        }
+
+        const documentInnerHtml = (this.contentNode as Document).documentElement.innerHTML;
+        var hasChanged = documentInnerHtml !== this.contentNodeSnapshot;
+        if (hasChanged) {
+            this.contentNodeSnapshot = documentInnerHtml;
+        }
+        return hasChanged;
+    }
 
     private buildRunButton(container: HTMLDivElement): void {
         const runCodeButton = document.createElement("button");


### PR DESCRIPTION
I encountered a bug where snippets wouldn't get re-rendered  when clicking the run snippets button and was always one change behind. I could only force the snippet to update by swapping between editor views.

https://github.com/user-attachments/assets/ddc98b09-efdb-4d86-920c-f77cf5448cdc

I found that this was caused due to how we decided to update the results in snippet-view.ts within the update function.
Here's the flow:
1. User updates their snippet and saves it to the editor
2. We run through the update function, on this run SnippetMetadata is updated
3. We get down to this conditional `if (content && (metaChanged || this.resultContainer.innerHTML === ""))`
and because the snippet meta data has updated we reinitialize the Iframe for the snippets result but reinject our contentNode html into the iframe. The content node is what we get back from the renderer and only gets set on button click, we therefore are not updating the actual contents of what is displayed to the user.
4. The user could then hit the run snippets button and we dispatch an event to run through the update function again.
5. At this point we have already seen the updated snippet meta data, so once we get down to the conditional to update the iframes content we skip over it.

**Describe your changes**
I address this issue by instead of comparing if the snippet meta data has changed I compare the contentNode's innerHtml to a snapshots. This makes it so that the snippet results are only updated on run button click.
