### PR TITLE
fix: preserve editor focus when opening dropdowns

### DIFF
--- a/.changeset/quiet-menus-stay.md
+++ b/.changeset/quiet-menus-stay.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-editor": patch
+---
+
+Keep editor dropdown menus open when activated with a mouse.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
                 "@playwright/test": "^1.42.1",
                 "@stackoverflow/commitlint-config": "^1.0.0",
                 "@stackoverflow/prettier-config": "^1.0.0",
-                "@stackoverflow/stacks": "^2.3.2",
+                "@stackoverflow/stacks": "^2.9.0",
                 "@stackoverflow/tsconfig": "^1.0.0",
                 "@types/jest": "^29.5.12",
                 "@types/markdown-it": "^14.0.0",
@@ -2436,11 +2436,10 @@
             }
         },
         "node_modules/@stackoverflow/stacks": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.7.0.tgz",
-            "integrity": "sha512-nn4tow6oTsYlpKwOcpPeKclFMvn0Py+rWCZppRWqcEVl9w2+U+nU7QyKsLzySvSFgXoo5hrBPWp5t7AlNVmF0A==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-2.9.0.tgz",
+            "integrity": "sha512-6VX9GTYFqsBFaelZ0sJ9YGZDa+1eLjr6Dh8r6cIh02SA/BcocWe0lxNZTcLpBQEKtX/9A0jTRsY3Au0BXcFJWQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@hotwired/stimulus": "^3.2.2",
                 "@popperjs/core": "^2.11.8"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "@playwright/test": "^1.42.1",
         "@stackoverflow/commitlint-config": "^1.0.0",
         "@stackoverflow/prettier-config": "^1.0.0",
-        "@stackoverflow/stacks": "^2.3.2",
+        "@stackoverflow/stacks": "^2.9.0",
         "@stackoverflow/tsconfig": "^1.0.0",
         "@types/jest": "^29.5.12",
         "@types/markdown-it": "^14.0.0",

--- a/src/stacks-editor/editor.ts
+++ b/src/stacks-editor/editor.ts
@@ -230,6 +230,7 @@ export class StacksEditor implements View {
         // create specific area for the editor menu
         const menuTarget = document.createElement("div");
         menuTarget.className = "d-flex overflow-x-auto ai-center px12 py4 pb0";
+        menuTarget.addEventListener("mousedown", (e) => e.preventDefault());
         this.pluginContainer.appendChild(menuTarget);
 
         // set the editors' menu containers to be the combo container

--- a/test/rich-text/editor.e2e.test.ts
+++ b/test/rich-text/editor.e2e.test.ts
@@ -58,6 +58,7 @@ test.describe.serial("rich-text mode", () => {
 
     test("should insert heading from dropdown", async () => {
         await enterTextAsMarkdown(page, "plain text");
+        await page.locator(editorSelector).focus();
         await expect(page.locator(headingPopoverSelector)).not.toHaveClass(
             /is-visible/,
             { timeout: 1000 }
@@ -68,6 +69,7 @@ test.describe.serial("rich-text mode", () => {
             /is-visible/,
             { timeout: 1000 }
         );
+        await expect(page.locator(editorSelector)).toBeFocused();
 
         await page.click(insertH1ButtonSelector);
         await expect(page.locator(headingPopoverSelector)).not.toHaveClass(

--- a/test/stacks-editor/editor.test.ts
+++ b/test/stacks-editor/editor.test.ts
@@ -1,0 +1,54 @@
+import { StacksEditor } from "../../src/stacks-editor/editor";
+
+jest.mock("../../src/shared/utils", () => {
+    const actual = jest.requireActual<typeof import("../../src/shared/utils")>(
+        "../../src/shared/utils"
+    );
+
+    return {
+        ...actual,
+        startStickyObservers: jest.fn(),
+    };
+});
+
+describe("StacksEditor", () => {
+    let editor: StacksEditor;
+    let target: HTMLElement;
+
+    beforeEach(() => {
+        target = document.createElement("div");
+        editor = new StacksEditor(target, "");
+    });
+
+    afterEach(() => editor.destroy());
+
+    it("prevents menu mouse interactions from blurring the editor", () => {
+        const dropdown = target.querySelector<HTMLElement>(
+            ".js-editor-menu .s-btn__dropdown"
+        );
+        const event = new MouseEvent("mousedown", {
+            bubbles: true,
+            cancelable: true,
+        });
+
+        dropdown.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("allows plugin controls to receive focus", () => {
+        const pluginTarget = target.querySelector<HTMLElement>(
+            ".js-plugin-container > div:last-child"
+        );
+        const input = document.createElement("input");
+        const event = new MouseEvent("mousedown", {
+            bubbles: true,
+            cancelable: true,
+        });
+        pluginTarget.appendChild(input);
+
+        input.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

- cancel `mousedown` within the built-in editor menu container so mouse activation does not blur the editor
- keep plugin controls outside the menu focusable
- add unit and browser regression coverage, with the test dependency updated to Stacks 2.9.0
- add a patch changeset

## Context

This fixes the underlying Stacks Editor focus-handling gap exposed by Stacks 2.9.0. When a mouse opened an editor dropdown, the editor click handler restored focus to the editor; Stacks then treated that focus move as leaving the trigger/popover pair and immediately dismissed the menu.

Stacks Editor already documents this focus-preservation behavior in two places: `setupPluginContainer()` says toolbar mouse interactions are cancelled to prevent the editor from blurring, and `MenuView` says the standard `StacksEditor` setup handles this automatically. However, the built-in setup never installed the documented `mousedown` handler. This change closes that existing implementation gap; Stacks 2.9's focus-leave behavior merely made the gap observable.

This is the upstream fix for the temporary Stack Overflow workarounds in [StackEng/StackOverflow#26004](https://github.com/StackEng/StackOverflow/pull/26004) and [StackEng/StackOverflow#26010](https://github.com/StackEng/StackOverflow/pull/26010).

## Testing

- `npm run lint`
- `npm run test:unit -- --runInBand` — 48 suites, 1,092 tests passed
- `npm run test:e2e` — 195 tests passed across Chromium, Firefox, and WebKit
- `npm run build`
- `git diff --check`
