### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @StackExchange/stacks


### PR DESCRIPTION
Assign the Stacks team as the default owner for all files in Stacks Editor.

### Changes

- Add a catch-all CODEOWNERS rule so the Stacks team is automatically requested on repository changes, matching the Stacks repository.
